### PR TITLE
Remove ui module; fab.ui is now an object.

### DIFF
--- a/py/fab/ui.py
+++ b/py/fab/ui.py
@@ -1,1 +1,0 @@
-from _hooks.ui import *


### PR DESCRIPTION
`fab.ui` is an object of `_hooks.ScriptUIHooks`. Having a `fab.ui` module is misleading and will cause issues.