### PR TITLE
Load nodes from User location

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -363,6 +363,8 @@ QString App::userNodePath() const
 
     path << "nodes";
 
+    QDir(path.join("/")).mkpath(".");
+
     return path.join("/");
 }
 

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -10,6 +10,7 @@
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QRegularExpression>
+#include <QStandardPaths>
 
 #include <cmath>
 
@@ -327,7 +328,7 @@ void App::setGlobalStyle()
                 .arg(Colors::base04.name()));
 }
 
-QString App::nodePath() const
+QString App::bundledNodePath() const
 {
     auto path = applicationDirPath().split("/");
 
@@ -352,6 +353,15 @@ QString App::nodePath() const
 #else
     path << "sb" << "nodes";
 #endif
+
+    return path.join("/");
+}
+
+QString App::userNodePath() const
+{
+    auto path = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation).split("/");
+
+    path << "nodes";
 
     return path.join("/");
 }

--- a/src/app/app.h
+++ b/src/app/app.h
@@ -66,7 +66,8 @@ public:
      *  Returns the path to the nodes directory
      *  (which varies depending on OS).
      */
-    QString nodePath() const;
+    QString bundledNodePath() const;
+    QString userNodePath() const;
 
     QAction* undoAction();
     QAction* redoAction();

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -172,7 +172,7 @@ void MainWindow::addNodeToMenu(QStringList category, QString name, QMenu* menu,
             [=]{ this->createNew(recenter, f, v); });
 }
 
-void MainWindow::populateUserScripts(QMenu* menu, bool recenter, Viewport* v)
+void MainWindow::populateNodeMenu(QMenu* menu, bool recenter, Viewport* v)
 {
     QDirIterator itr(App::instance()->nodePath(),
                      QDirIterator::Subdirectories);
@@ -245,7 +245,7 @@ void MainWindow::populateMenu(QMenu* menu, bool recenter, Viewport* v)
         menu->addMenu(c);
     menu->addSeparator();
 
-    populateUserScripts(menu, recenter, v);
+    populateNodeMenu(menu, recenter, v);
 
     menu->addSeparator();
     addNodeToMenu(QStringList(), "Script", menu, recenter,

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -174,16 +174,25 @@ void MainWindow::addNodeToMenu(QStringList category, QString name, QMenu* menu,
 
 void MainWindow::populateNodeMenu(QMenu* menu, bool recenter, Viewport* v)
 {
-    QDirIterator itr(App::instance()->nodePath(),
+    QDirIterator bitr(App::instance()->bundledNodePath(),
+                     QDirIterator::Subdirectories);
+    QDirIterator uitr(App::instance()->userNodePath(),
                      QDirIterator::Subdirectories);
     QList<QRegExp> title_regexs= {QRegExp(".*title\\('+([^']+)'+\\).*"),
                                   QRegExp(".*title\\(\"+([^\"]+)\"+\\).*")};
 
     // Extract all of valid filenames into a QStringList.
     QStringList node_filenames;
-    while (itr.hasNext())
+    while (bitr.hasNext())
     {
-        auto n = itr.next();
+        auto n = bitr.next();
+        if (n.endsWith(".node"))
+            node_filenames.append(n);
+    }
+
+    while (uitr.hasNext())
+    {
+        auto n = uitr.next();
         if (n.endsWith(".node"))
             node_filenames.append(n);
     }

--- a/src/ui/main_window.h
+++ b/src/ui/main_window.h
@@ -63,7 +63,7 @@ private:
                        bool recenter, NodeConstructorFunction f,
                        Viewport* v=NULL);
 
-    void populateUserScripts(QMenu* menu, bool recenter=true, Viewport* v=NULL);
+    void populateNodeMenu(QMenu* menu, bool recenter=true, Viewport* v=NULL);
 
     QString window_type;
     Ui::MainWindow *ui;


### PR DESCRIPTION
Implements #68, as I've discussed on the list.

Checks the platform-specific app data directory (eg, Linux: `~/.local/share/antimony`) for node scripts. If it doesn't exist, it will create it (to ease finding it).

This enables the development and deployment of nodes from 3rd-parties, node markets, etc.

(This is my first time in Qt and in C++, so please let me know if I did something wrong.)