### PR TITLE
Improve normals

### DIFF
--- a/qt/fab.pri
+++ b/qt/fab.pri
@@ -9,6 +9,7 @@ SOURCES += \
     ../src/fab/tree/math/math_f.c \
     ../src/fab/tree/math/math_i.c \
     ../src/fab/tree/math/math_r.c \
+    ../src/fab/tree/math/math_g.c \
     ../src/fab/tree/node/node_c.c \
     ../src/fab/tree/node/opcodes.c \
     ../src/fab/tree/node/printers.c \
@@ -34,6 +35,7 @@ HEADERS += \
     ../src/fab/tree/math/math_f.h \
     ../src/fab/tree/math/math_i.h \
     ../src/fab/tree/math/math_r.h \
+    ../src/fab/tree/math/math_g.h \
     ../src/fab/tree/node/node.h \
     ../src/fab/tree/node/opcodes.h \
     ../src/fab/tree/node/printers.h \

--- a/src/export/export_heightmap.cpp
+++ b/src/export/export_heightmap.cpp
@@ -109,7 +109,7 @@ void ExportHeightmapTask::render()
         d16_rows[i] = d16 + (r.ni * i);
 
     memset(d16, 0, 2 * r.ni * r.nj);
-    render16(shape.tree.get(), r, d16_rows, halt);
+    render16(shape.tree.get(), r, d16_rows, halt, NULL);
 
     // These bounds will be stored to give the .png real-world units.
     float bounds[6] = {

--- a/src/export/export_heightmap.cpp
+++ b/src/export/export_heightmap.cpp
@@ -106,9 +106,9 @@ void ExportHeightmapTask::render()
     uint16_t** d16_rows(new uint16_t*[r.nj]);
 
     for (unsigned i=0; i < r.nj; ++i)
-        d16_rows[i] = d16 + (r.ni * i);
+        d16_rows[i] = &d16[r.ni * i];
 
-    memset(d16, 0, 2 * r.ni * r.nj);
+    memset(d16, 0, r.ni * r.nj * sizeof(uint16_t));
     render16(shape.tree.get(), r, d16_rows, halt, NULL);
 
     // These bounds will be stored to give the .png real-world units.

--- a/src/fab/tree/eval.c
+++ b/src/fab/tree/eval.c
@@ -207,5 +207,5 @@ derivative* eval_g(MathTree* tree, const Region r)
         }
     }
 
-    return tree->head->results.r;
+    return (derivative*)(tree->head->results.r);
 }

--- a/src/fab/tree/eval.c
+++ b/src/fab/tree/eval.c
@@ -8,6 +8,7 @@
 #include "tree/math/math_f.h"
 #include "tree/math/math_i.h"
 #include "tree/math/math_r.h"
+#include "tree/math/math_g.h"
 
 float eval_f(MathTree* tree, const float x, const float y, const float z)
 {
@@ -148,6 +149,58 @@ float* eval_r(MathTree* tree, const Region r)
                 case OP_X:      X_r(r.X, R, c); break;
                 case OP_Y:      Y_r(r.Y, R, c); break;
                 case OP_Z:      Z_r(r.Z, R, c); break;
+                default:
+                    printf("Unknown opcode!\n");
+            }
+        }
+    }
+
+    return tree->head->results.r;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+derivative* eval_g(MathTree* tree, const Region r)
+{
+    Node* node = NULL;
+    int c = r.voxels;
+
+    for (unsigned level=0; level < tree->num_levels; ++level) {
+        for (unsigned n=0; n < tree->active[level]; ++n) {
+
+            node = tree->nodes[level][n];
+
+            derivative *A = (derivative*)(node->lhs ? node->lhs->results.r
+                                                    : NULL),
+                       *B = (derivative*)(node->rhs ? node->rhs->results.r
+                                                   : NULL),
+                       *R = (derivative*)(node->results.r);
+
+            switch (node->opcode) {
+                case OP_ADD:    add_g(A, B, R, c); break;
+                case OP_SUB:    sub_g(A, B, R, c); break;
+                case OP_MUL:    mul_g(A, B, R, c); break;
+                case OP_DIV:    div_g(A, B, R, c); break;
+                case OP_MIN:    min_g(A, B, R, c); break;
+                case OP_MAX:    max_g(A, B, R, c); break;
+                case OP_POW:    pow_g(A, B, R, c); break;
+
+                case OP_ABS:    abs_g(A, R, c); break;
+                case OP_SQUARE: square_g(A, R, c); break;
+                case OP_SQRT:   sqrt_g(A, R, c); break;
+                case OP_SIN:    sin_g(A, R, c); break;
+                case OP_COS:    cos_g(A, R, c); break;
+                case OP_TAN:    tan_g(A, R, c); break;
+                case OP_ASIN:   asin_g(A, R, c); break;
+                case OP_ACOS:   acos_g(A, R, c); break;
+                case OP_ATAN:   atan_g(A, R, c); break;
+                case OP_NEG:    neg_g(A, R, c); break;
+                case OP_EXP:    exp_g(A, R, c); break;
+
+                case OP_CONST:  break;
+                case OP_X:      X_g(r.X, R, c); break;
+                case OP_Y:      Y_g(r.Y, R, c); break;
+                case OP_Z:      Z_g(r.Z, R, c); break;
                 default:
                     printf("Unknown opcode!\n");
             }

--- a/src/fab/tree/eval.h
+++ b/src/fab/tree/eval.h
@@ -11,6 +11,7 @@ extern "C" {
 
 // Forward declarations
 struct MathTree_;
+struct derivative_;
 
 
 /** @brief Evaluates a math expression at a given floating-point position.
@@ -30,6 +31,10 @@ Interval  eval_i(struct MathTree_* n, const Interval X,
     @details Results are stored in n->head->results.r
 */
 float*  eval_r(struct MathTree_* n, const Region r);
+
+/** @brief Evaluates partial derivatives over a set of many position.
+*/
+struct derivative_* eval_g(struct MathTree_* tree, const Region r);
 
 #ifdef __cplusplus
 }

--- a/src/fab/tree/math/math_g.c
+++ b/src/fab/tree/math/math_g.c
@@ -48,8 +48,9 @@ derivative* div_g(const derivative* A, const derivative* B,
         R[q].v = A[q].v / B[q].v;
 
         // Quotient rule
+        const float p = pow(B[q].v, 2);
         for (int i=1; i < 4; ++i)
-            INDEX(R) = (INDEX(A)*B[q].v - A[q].v*INDEX(B)) / pow(B[q].v, 2);
+            INDEX(R) = (INDEX(A)*B[q].v - A[q].v*INDEX(B)) / p;
     }
     return R;
 }
@@ -93,9 +94,10 @@ derivative* pow_g(const derivative* A, const derivative* B,
     {
         R[q].v = pow(A[q].v, B[q].v);
 
+        const float p = pow(A[q].v, B[q].v - 1);
+        const float m = A[q].v * log(A[q].v);
         for (int i=1; i < 4; ++i)
-            INDEX(R) = pow(A[q].v, B[q].v - 1) *
-                      (INDEX(A)*B[q].v + A[q].v*INDEX(B)*log(A[q].v));
+            INDEX(R) = p * (INDEX(A)*B[q].v + m * INDEX(B));
     }
 
     return R;
@@ -126,8 +128,9 @@ derivative* square_g(const derivative* A, derivative* R, int c)
         R[q].v = A[q].v*A[q].v;
 
         // Prouduct rule
+        const float a = 2 * A[q].v;
         for (int i=1; i < 4; ++i)
-            INDEX(R) = 2 * A[q].v * INDEX(A);
+            INDEX(R) = a * INDEX(A);
     }
     return R;
 }
@@ -143,8 +146,9 @@ derivative* sqrt_g(const derivative* A, derivative* R, int c)
         else
         {
             R[q].v = sqrt(A[q].v);
+            const float r = R[q].v * 2;
             for (int i=1; i < 4; ++i)
-                INDEX(R) = INDEX(A) / (2 * sqrt(A[q].v));
+                INDEX(R) = INDEX(A) / r;
         }
     return R;
 }
@@ -154,8 +158,9 @@ derivative* sin_g(const derivative* A, derivative* R, int c)
     for (int q = 0; q < c; ++q)
     {
         R[q].v = sin(A[q].v);
+        const float c = cos(A[q].v);
         for (int i=1; i < 4; ++i)
-            INDEX(R) = INDEX(A) * cos(A[q].v);
+            INDEX(R) = INDEX(A) * c;
     }
     return R;
 }
@@ -165,8 +170,9 @@ derivative* cos_g(const derivative* A, derivative* R, int c)
     for (int q = 0; q < c; ++q)
     {
         R[q].v = cos(A[q].v);
+        const float s = -sin(A[q].v);
         for (int i=1; i < 4; ++i)
-            INDEX(R) = INDEX(A) * (-sin(A[q].v));
+            INDEX(R) = INDEX(A) * s;
     }
     return R;
 }
@@ -176,8 +182,9 @@ derivative* tan_g(const derivative* A, derivative* R, int c)
     for (int q = 0; q < c; ++q)
     {
         R[q].v = tan(A[q].v);
+        const float d = pow(cos(A[q].v), 2);
         for (int i=1; i < 4; ++i)
-            INDEX(R) = INDEX(A) / pow(cos(A[q].v), 2);
+            INDEX(R) = INDEX(A) / d;
     }
     return R;
 }
@@ -194,8 +201,9 @@ derivative* asin_g(const derivative* A, derivative* R, int c)
         else
         {
             R[q].v = asin(A[q].v);
+            const float d = sqrt(1 - pow(A[q].v, 2));
             for (int i=1; i < 4; ++i)
-                INDEX(R) = INDEX(A) / sqrt(1 - pow(A[q].v, 2));
+                INDEX(R) = INDEX(A) / d;
         }
     }
     return R;
@@ -213,8 +221,9 @@ derivative* acos_g(const derivative* A, derivative* R, int c)
         else
         {
             R[q].v = acos(A[q].v);
+            const float d = -sqrt(1 - pow(A[q].v, 2));
             for (int i=1; i < 4; ++i)
-                INDEX(R) = -INDEX(A) / sqrt(1 - pow(A[q].v, 2));
+                INDEX(R) = INDEX(A) / d;
         }
     }
     return R;
@@ -225,8 +234,9 @@ derivative* atan_g(const derivative* A, derivative* R, int c)
     for (int q = 0; q < c; ++q)
     {
         R[q].v = atan(A[q].v);
+        const float d = pow(A[q].v, 2) + 1;
         for (int i=1; i < 4; ++i)
-            INDEX(R) = INDEX(A) / (pow(A[q].v, 2) + 1);
+            INDEX(R) = INDEX(A) / d;
     }
     return R;
 }
@@ -244,8 +254,9 @@ derivative* exp_g(const derivative* A, derivative* R, int c)
     for (int q = 0; q < c; ++q)
     {
         R[q].v = exp(A[q].v);
+        const float e = exp(A[q].v);
         for (int i=1; i < 4; ++i)
-            INDEX(R) = exp(A[q].v) * INDEX(A);
+            INDEX(R) = e * INDEX(A);
     }
     return R;
 }

--- a/src/fab/tree/math/math_g.c
+++ b/src/fab/tree/math/math_g.c
@@ -1,0 +1,286 @@
+#include <string.h>
+#include <math.h>
+
+#include "tree/math/math_g.h"
+
+float* add_g(const float (*A)[4], const float (*B)[4],
+             float (*R)[4], int c)
+{
+    for (int q = 0; q < c; ++q)
+        for (int i=0; i < 4; ++i)
+            R[q][i] = A[q][i] + B[q][i];
+    return R;
+}
+
+float* sub_g(const float (*A)[4], const float (*B)[4],
+             float (*R)[4], int c)
+{
+    for (int q = 0; q < c; ++q)
+    {
+        for (int i=0; i < 4; ++i)
+            R[q][i] = A[q][i] - B[q][i];
+    }
+    return R;
+}
+
+float* mul_g(const float (*A)[4], const float (*B)[4],
+             float (*R)[4], int c)
+{
+    for (int q = 0; q < c; ++q)
+    {
+        R[q][0] = A[q][0] * B[q][0];
+
+        // Product rule
+        R[q][1] = A[q][0] * B[q][1] + A[q][1] * B[q][0];
+        R[q][2] = A[q][0] * B[q][2] + A[q][2] * B[q][0];
+        R[q][3] = A[q][0] * B[q][3] + A[q][3] * B[q][0];
+    }
+    return R;
+}
+
+float* div_g(const float (*A)[4], const float (*B)[4],
+             float (*R)[4], int c)
+{
+    for (int q = 0; q < c; ++q)
+    {
+        R[q][0] = A[q][0] / B[q][0];
+
+        // Quotient rule
+        R[q][1] = (A[q][1]*B[q][0] - A[q][0]*B[q][1]) / pow(B[q][0], 2);
+        R[q][2] = (A[q][2]*B[q][0] - A[q][0]*B[q][2]) / pow(B[q][0], 2);
+        R[q][3] = (A[q][3]*B[q][0] - A[q][0]*B[q][3]) / pow(B[q][0], 2);
+    }
+    return R;
+}
+
+float* min_g(const float (*A)[4], const float (*B)[4],
+             float (*R)[4], int c)
+{
+    for (int q = 0; q < c; ++q)
+    {
+        if (A[q][0] < B[q][0])
+            for (int i=1; i < 4; ++i)
+                R[q][i] = A[q][i];
+        else
+            for (int i=1; i < 4; ++i)
+                R[q][i] = B[q][i];
+    }
+    return R;
+}
+
+float* max_g(const float (*A)[4], const float (*B)[4],
+             float (*R)[4], int c)
+{
+    for (int q = 0; q < c; ++q)
+    {
+        if (A[q][0] >= B[q][0])
+            for (int i=1; i < 4; ++i)
+                R[q][i] = A[q][i];
+        else
+            for (int i=1; i < 4; ++i)
+                R[q][i] = B[q][i];
+    }
+    return R;
+}
+
+float* pow_g(const float (*A)[4], const float (*B)[4],
+             float (*R)[4], int c)
+{
+    for (int q = 0; q < c; ++q)
+    {
+        R[q][0] = pow(A[q][0], B[q][0]);
+
+        for (int i=1; i < 4; ++i)
+            R[q][i] = pow(A[q][0], B[q][0] - 1) *
+                      (A[q][i]*B[q][0] + A[q][0]*B[q][i]*log(A[q][0]))
+    }
+
+    return R;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+float* abs_g(const float (*A)[4], float (*R)[4], int c)
+{
+    for (int q=0; q < c; ++q)
+    {
+        R[q][0] = fabs(A[q][0]);
+        if (A[q][0] < 0)
+            for (int i=1; i < 4; ++i)
+                R[q][i] = -A[q][i];
+        else
+            for (int i=1; i < 4; ++i)
+                R[q][i] = A[q][i];
+    }
+
+    return R;
+}
+
+float* square_g(const float (*A)[4], float (*R)[4], int c)
+{
+    for (int q = 0; q < c; ++q)
+    {
+        R[q][0] = A[q][0]*A[q][0];
+
+        // Prouduct rule
+        for (int i=1; i < 4; ++i)
+            R[q][i] = 2 * A[q][0] * A[q][i];
+    }
+    return R;
+}
+
+float* sqrt_g(const float (*A)[4], float (*R)[4], int c)
+{
+    for (int q = 0; q < c; ++q)
+        if (A[q] < 0)
+        {
+            for (int i=0; i < 4; ++i)
+                R[q][i] = 0;
+        }
+        else
+        {
+            R[q][0] = sqrt(A[q][0]);
+            for (int i=1; i < 4; ++i)
+                R[q][i] = A[q][i] / (2 * sqrt(A[q][0]))
+        }
+    return R;
+}
+
+float* sin_g(const float (*A)[4], float (*R)[4], int c)
+{
+    for (int q = 0; q < c; ++q)
+    {
+        R[q][0] = sin(A[q][0]);
+        for (int i=1; i < 4; ++i)
+            R[q][i] = A[q][i] * cos(A[q][0]);
+    }
+    return R;
+}
+
+float* cos_g(const float (*A)[4], float (*R)[4], int c)
+{
+    for (int q = 0; q < c; ++q)
+    {
+        R[q][0] = cos(A[q][0]);
+        for (int i=1; i < 4; ++i)
+            R[q][i] = A[q][i] * (-sin(A[q][0]));
+    }
+    return R;
+}
+
+float* tan_g(const float (*A)[4], float (*R)[4], int c)
+{
+    for (int q = 0; q < c; ++q)
+    {
+        R[q][0] = tan(A[q][0]);
+        for (int i=1; i < 4; ++i)
+            R[q][i] = A[q][i] / pow(cos(A[q][0]), 2);
+    }
+    return R;
+}
+
+float* asin_g(const float (*A)[4], float (*R)[4], int c)
+{
+    for (int q = 0; q < c; ++q)
+    {
+        if (A[q][0] < -1 || A[q][0] > 1)
+        {
+            for (int i=0; i < 4; ++i)
+                R[q][i] = 0;
+        }
+        else
+        {
+            R[q][0] = asin(A[q][0]);
+            for (int i=1; i < 4; ++i)
+                R[q][i] = A[q][i] / sqrt(1 - pow(A[q][0], 2));
+        }
+    }
+    return R;
+}
+
+float* acos_g(const float (*A)[4], float (*R)[4], int c)
+{
+    for (int q = 0; q < c; ++q)
+    {
+        if (A[q][0] < -1 || A[q][0] > 1)
+        {
+            for (int i=0; i < 4; ++i)
+                R[q][i] = 0;
+        }
+        else
+        {
+            R[q][0] = acos(A[q][0]);
+            for (int i=1; i < 4; ++i)
+                R[q][i] = -A[q][i] / sqrt(1 - pow(A[q][0], 2));
+        }
+    }
+    return R;
+}
+
+float* atan_g(const float (*A)[4], float (*R)[4], int c)
+{
+    for (int q = 0; q < c; ++q)
+    {
+        R[q][0] = atan(A[q][0]);
+        for (int i=1; i < 4; ++i)
+            R[q][i] = A[q][i] / (pow(A[q][0], 2) + 1);
+    }
+    return R;
+}
+
+float* neg_g(const float (*A)[4], float (*R)[4], int c)
+{
+    for (int q=0; q < c; ++q)
+        for (int i=0; i < 4; ++i)
+            R[q][i] = -A[q][i];
+    return R;
+}
+
+float* exp_g(const float (*A)[4], float (*R)[4], int c)
+{
+    for (int q = 0; q < c; ++q)
+    {
+        R[q][0] = exp(A[q][0]);
+        for (int i=1; i < 3; ++i)
+            R[q][i] = exp(A[q][0]) * A[q][i];
+    }
+    return R;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+float* X_g(const float (*X), float (*R)[4], int c)
+{
+    for (int q = 0; q < c; ++q)
+    {
+        R[q][0] = X[q];
+        R[q][1] = 1;
+        R[q][2] = 0;
+        R[q][3] = 0;
+    }
+    return R;
+}
+
+float* Y_g(const float (*Y), float (*R)[4], int c)
+{
+    for (int q = 0; q < c; ++q)
+    {
+        R[q][0] = Y[q];
+        R[q][1] = 0;
+        R[q][2] = 1;
+        R[q][3] = 0;
+    }
+    return R;
+}
+
+float* Z_g(const float (*Z), float (*R)[4], int c)
+{
+    for (int q = 0; q < c; ++q)
+    {
+        R[q][0] = Z[q];
+        R[q][1] = 0;
+        R[q][2] = 0;
+        R[q][3] = 1;
+    }
+    return R;
+}

--- a/src/fab/tree/math/math_g.c
+++ b/src/fab/tree/math/math_g.c
@@ -6,8 +6,9 @@
 // Cast the struct to an array so that we can iterate over it.
 #define INDEX(A) ((float*)(&A[q]))[i]
 
-derivative* add_g(const derivative* A, const derivative* B,
-             derivative* R, int c)
+derivative* add_g(const derivative* restrict A,
+                  const derivative* restrict B,
+                  derivative* restrict R, int c)
 {
     for (int q = 0; q < c; ++q)
         for (int i=0; i < 4; ++i)
@@ -15,8 +16,9 @@ derivative* add_g(const derivative* A, const derivative* B,
     return R;
 }
 
-derivative* sub_g(const derivative* A, const derivative* B,
-             derivative* R, int c)
+derivative* sub_g(const derivative* restrict A,
+                  const derivative* restrict B,
+                  derivative* restrict R, int c)
 {
     for (int q = 0; q < c; ++q)
     {
@@ -26,8 +28,9 @@ derivative* sub_g(const derivative* A, const derivative* B,
     return R;
 }
 
-derivative* mul_g(const derivative* A, const derivative* B,
-             derivative* R, int c)
+derivative* mul_g(const derivative* restrict A,
+                  const derivative* restrict B,
+                  derivative* restrict R, int c)
 {
     for (int q = 0; q < c; ++q)
     {
@@ -40,8 +43,9 @@ derivative* mul_g(const derivative* A, const derivative* B,
     return R;
 }
 
-derivative* div_g(const derivative* A, const derivative* B,
-             derivative* R, int c)
+derivative* div_g(const derivative* restrict A,
+                  const derivative* restrict B,
+                  derivative* restrict R, int c)
 {
     for (int q = 0; q < c; ++q)
     {
@@ -55,8 +59,9 @@ derivative* div_g(const derivative* A, const derivative* B,
     return R;
 }
 
-derivative* min_g(const derivative* A, const derivative* B,
-             derivative* R, int c)
+derivative* min_g(const derivative* restrict A,
+                  const derivative* restrict B,
+                  derivative* restrict R, int c)
 {
     for (int q = 0; q < c; ++q)
     {
@@ -71,8 +76,9 @@ derivative* min_g(const derivative* A, const derivative* B,
     return R;
 }
 
-derivative* max_g(const derivative* A, const derivative* B,
-             derivative* R, int c)
+derivative* max_g(const derivative* restrict A,
+                  const derivative* restrict B,
+                  derivative* restrict R, int c)
 {
     for (int q = 0; q < c; ++q)
     {
@@ -87,8 +93,9 @@ derivative* max_g(const derivative* A, const derivative* B,
     return R;
 }
 
-derivative* pow_g(const derivative* A, const derivative* B,
-             derivative* R, int c)
+derivative* pow_g(const derivative* restrict A,
+                  const derivative* restrict B,
+                  derivative* restrict R, int c)
 {
     for (int q = 0; q < c; ++q)
     {
@@ -105,7 +112,8 @@ derivative* pow_g(const derivative* A, const derivative* B,
 
 ////////////////////////////////////////////////////////////////////////////////
 
-derivative* abs_g(const derivative* A, derivative* R, int c)
+derivative* abs_g(const derivative* restrict A,
+                  derivative* restrict R, int c)
 {
     for (int q=0; q < c; ++q)
     {
@@ -121,7 +129,8 @@ derivative* abs_g(const derivative* A, derivative* R, int c)
     return R;
 }
 
-derivative* square_g(const derivative* A, derivative* R, int c)
+derivative* square_g(const derivative* restrict A,
+                     derivative* restrict R, int c)
 {
     for (int q = 0; q < c; ++q)
     {
@@ -135,7 +144,8 @@ derivative* square_g(const derivative* A, derivative* R, int c)
     return R;
 }
 
-derivative* sqrt_g(const derivative* A, derivative* R, int c)
+derivative* sqrt_g(const derivative* restrict A,
+                   derivative* restrict R, int c)
 {
     for (int q = 0; q < c; ++q)
         if (A[q].v < 0)
@@ -153,7 +163,8 @@ derivative* sqrt_g(const derivative* A, derivative* R, int c)
     return R;
 }
 
-derivative* sin_g(const derivative* A, derivative* R, int c)
+derivative* sin_g(const derivative* restrict A,
+                  derivative* restrict R, int c)
 {
     for (int q = 0; q < c; ++q)
     {
@@ -165,7 +176,8 @@ derivative* sin_g(const derivative* A, derivative* R, int c)
     return R;
 }
 
-derivative* cos_g(const derivative* A, derivative* R, int c)
+derivative* cos_g(const derivative* restrict A,
+                  derivative* restrict R, int c)
 {
     for (int q = 0; q < c; ++q)
     {
@@ -177,7 +189,8 @@ derivative* cos_g(const derivative* A, derivative* R, int c)
     return R;
 }
 
-derivative* tan_g(const derivative* A, derivative* R, int c)
+derivative* tan_g(const derivative* restrict A,
+                  derivative* restrict R, int c)
 {
     for (int q = 0; q < c; ++q)
     {
@@ -189,7 +202,8 @@ derivative* tan_g(const derivative* A, derivative* R, int c)
     return R;
 }
 
-derivative* asin_g(const derivative* A, derivative* R, int c)
+derivative* asin_g(const derivative* restrict A,
+                   derivative* restrict R, int c)
 {
     for (int q = 0; q < c; ++q)
     {
@@ -209,7 +223,8 @@ derivative* asin_g(const derivative* A, derivative* R, int c)
     return R;
 }
 
-derivative* acos_g(const derivative* A, derivative* R, int c)
+derivative* acos_g(const derivative* restrict A,
+                   derivative* restrict R, int c)
 {
     for (int q = 0; q < c; ++q)
     {
@@ -229,7 +244,8 @@ derivative* acos_g(const derivative* A, derivative* R, int c)
     return R;
 }
 
-derivative* atan_g(const derivative* A, derivative* R, int c)
+derivative* atan_g(const derivative* restrict A,
+                   derivative* restrict R, int c)
 {
     for (int q = 0; q < c; ++q)
     {
@@ -241,7 +257,8 @@ derivative* atan_g(const derivative* A, derivative* R, int c)
     return R;
 }
 
-derivative* neg_g(const derivative* A, derivative* R, int c)
+derivative* neg_g(const derivative* restrict A,
+                   derivative* restrict R, int c)
 {
     for (int q=0; q < c; ++q)
         for (int i=0; i < 4; ++i)
@@ -249,7 +266,8 @@ derivative* neg_g(const derivative* A, derivative* R, int c)
     return R;
 }
 
-derivative* exp_g(const derivative* A, derivative* R, int c)
+derivative* exp_g(const derivative* restrict A,
+                   derivative* restrict R, int c)
 {
     for (int q = 0; q < c; ++q)
     {
@@ -263,7 +281,8 @@ derivative* exp_g(const derivative* A, derivative* R, int c)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-derivative* X_g(const float* X, derivative* R, int c)
+derivative* X_g(const float* restrict X,
+                derivative* restrict R, int c)
 {
     for (int q = 0; q < c; ++q)
     {
@@ -275,7 +294,8 @@ derivative* X_g(const float* X, derivative* R, int c)
     return R;
 }
 
-derivative* Y_g(const float* Y, derivative* R, int c)
+derivative* Y_g(const float* restrict Y,
+                derivative* restrict R, int c)
 {
     for (int q = 0; q < c; ++q)
     {
@@ -287,7 +307,8 @@ derivative* Y_g(const float* Y, derivative* R, int c)
     return R;
 }
 
-derivative* Z_g(const float* Z, derivative* R, int c)
+derivative* Z_g(const float* restrict Z,
+                derivative* restrict R, int c)
 {
     for (int q = 0; q < c; ++q)
     {

--- a/src/fab/tree/math/math_g.h
+++ b/src/fab/tree/math/math_g.h
@@ -1,0 +1,57 @@
+#ifndef MATH_G_H
+#define MATH_G_H
+
+#include "tree/math/math_defines.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @file tree/math/math_g.h
+    @brief Functions for finding partial derivatives on multiple samples.
+    @details These functions take in input arrays A and B,
+    and array point count c.  Results are stored in the array R.
+*/
+
+typedef struct derivative_
+{
+    float v;
+    float dx;
+    float dy;
+    float dz;
+} derivative;
+
+// Binary functions
+derivative* add_g(const derivative* A, const derivative* B, derivative* R, int c);
+derivative* sub_g(const derivative* A, const derivative* B, derivative* R, int c);
+derivative* mul_g(const derivative* A, const derivative* B, derivative* R, int c);
+derivative* div_g(const derivative* A, const derivative* B, derivative* R, int c);
+
+derivative* min_g(const derivative* A, const derivative* B, derivative* R, int c);
+derivative* max_g(const derivative* A, const derivative* B, derivative* R, int c);
+
+derivative* pow_g(const derivative* A, const derivative* B, derivative* R, int c);
+
+// Unary functions
+derivative* abs_g(const derivative* A, derivative* R, int c);
+derivative* square_g(const derivative* A, derivative* R, int c);
+derivative* sqrt_g(const derivative* A, derivative* R, int c);
+derivative* sin_g(const derivative* A, derivative* R, int c);
+derivative* cos_g(const derivative* A, derivative* R, int c);
+derivative* tan_g(const derivative* A, derivative* R, int c);
+derivative* asin_g(const derivative* A, derivative* R, int c);
+derivative* acos_g(const derivative* A, derivative* R, int c);
+derivative* atan_g(const derivative* A, derivative* R, int c);
+derivative* neg_g(const derivative* A, derivative* R, int c);
+derivative* exp_g(const derivative* A, derivative* R, int c);
+
+// Variables
+derivative* X_g(const float* X, derivative* R, int c);
+derivative* Y_g(const float* Y, derivative* R, int c);
+derivative* Z_g(const float* Z, derivative* R, int c);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/fab/tree/render.c
+++ b/src/fab/tree/render.c
@@ -192,7 +192,7 @@ void shade_pixels8(unsigned count, float (*normals)[3],
     }
 }
 
-void shaded8(struct MathTree_ *tree, Region region, uint8_t **depth,
+void shaded8(struct MathTree_ *tree, Region region, uint16_t **depth,
              uint8_t (**out)[3], volatile int *halt,
              void (*callback)())
 {
@@ -219,7 +219,7 @@ void shaded8(struct MathTree_ *tree, Region region, uint8_t **depth,
             {
                 X[count] = region.X[i];
                 Y[count] = region.Y[j];
-                Z[count] = region.Z[0] + depth[j][i] / 255.0f *
+                Z[count] = region.Z[0] + depth[j][i] / 65535.0f *
                             (region.Z[region.nk] - region.Z[0]);
 
                 is[count] = i;

--- a/src/fab/tree/render.c
+++ b/src/fab/tree/render.c
@@ -163,7 +163,7 @@ void get_normals8(MathTree* tree,
     dummy.Z = Z;
     dummy.voxels = count;
 
-    derivative* result = eval_r(tree, dummy);
+    derivative* result = eval_g(tree, dummy);
 
     // Calculate normals and copy over.
     for (int i=0; i < count; ++i)
@@ -171,7 +171,6 @@ void get_normals8(MathTree* tree,
         const float x = result[i].dx;
         const float y = result[i].dy;
         const float z = result[i].dz;
-        printf("%f %f %f    %f %f %f\n", X[i], Y[i], Z[i], x, y, z);
 
         const float dist = sqrt(pow(x,2) + pow(y, 2) + pow(z,2));
         normals[i][0] = dist ? x/dist : 0;

--- a/src/fab/tree/render.c
+++ b/src/fab/tree/render.c
@@ -250,15 +250,16 @@ void shaded8(struct MathTree_ *tree, Region region, uint8_t **depth,
 
 ////////////////////////////////////////////////////////////////////////////////
 void render16(MathTree* tree, Region region,
-              uint16_t** img, volatile int* halt)
+              uint16_t** img, volatile int* halt,
+              void (*callback)())
 {
-    if (tree == NULL)  return;
-
     // Special interrupt system, set asynchronously by on high
     if (*halt)  return;
 
     // Render pixel-by-pixel if we're below a certain size.
     if (region.voxels > 0 && region.voxels < MIN_VOLUME) {
+        if (callback)
+            (*callback)();
         region16(tree, region, img);
         return;
     }
@@ -305,8 +306,8 @@ void render16(MathTree* tree, Region region,
         Region A, B;
         bisect(region, &A, &B);
 
-        render16(tree, B, img, halt);
-        render16(tree, A, img, halt);
+        render16(tree, B, img, halt, callback);
+        render16(tree, A, img, halt, callback);
     }
 
 #if PRUNE

--- a/src/fab/tree/render.h
+++ b/src/fab/tree/render.h
@@ -21,7 +21,7 @@ void render8(struct MathTree_* tree, Region region,
              uint8_t** img, volatile int* halt,
              void (*callback)());
 
-void shaded8(struct MathTree_* tree, Region region, uint8_t** depth,
+void shaded8(struct MathTree_* tree, Region region, uint16_t** depth,
              uint8_t (**out)[3], volatile int* halt,
              void (*callback)());
 

--- a/src/fab/tree/render.h
+++ b/src/fab/tree/render.h
@@ -32,7 +32,8 @@ void shaded8(struct MathTree_* tree, Region region, uint8_t** depth,
     @param halt Flag to abort (if *halt becomes true)
 */
 void render16(struct MathTree_* tree, Region region,
-             uint16_t** img, volatile int* halt);
+              uint16_t** img, volatile int* halt,
+              void (*callback)());
 
 
 #ifdef __cplusplus

--- a/src/render/render_image.cpp
+++ b/src/render/render_image.cpp
@@ -52,8 +52,8 @@ void RenderImage::render(Shape *shape)
     Region r = (Region) {
             .imin=0, .jmin=0, .kmin=0,
             .ni=(uint32_t)depth.width(), .nj=(uint32_t)depth.height(),
-            .nk=uint32_t(fmax(1, (shape->bounds.zmax -
-                                  shape->bounds.zmin) * scale))
+            .nk=uint32_t(fmin(255, fmax(1, (shape->bounds.zmax -
+                                  shape->bounds.zmin) * scale)))
     };
 
     build_arrays(&r, shape->bounds.xmin, shape->bounds.ymin, shape->bounds.zmin,

--- a/src/render/render_image.cpp
+++ b/src/render/render_image.cpp
@@ -36,30 +36,30 @@ void RenderImage::render(Shape *shape)
 {
     depth.fill(0x000000);
 
-    uint8_t* d8(new uint8_t[depth.width() * depth.height()]);
-    uint8_t** d8_rows(new uint8_t*[depth.height()]);
+    uint16_t* d16(new uint16_t[depth.width() * depth.height()]);
+    uint16_t** d16_rows(new uint16_t*[depth.height()]);
     uint8_t (*s8)[3] = new uint8_t[depth.width() * depth.height()][3];
     uint8_t (**s8_rows)[3] = new decltype(s8)[depth.height()];
 
     for (int i=0; i < depth.height(); ++i)
     {
-        d8_rows[i] = d8 + (depth.width() * i);
-        s8_rows[i] = s8 + (depth.width() * i);
+        d16_rows[i] = &d16[depth.width() * i];
+        s8_rows[i] = &s8[depth.width() * i];
     }
-    memset(d8, 0, depth.width() * depth.height());
+    memset(d16, 0, depth.width() * depth.height() * 2);
     memset(s8, 0, depth.width() * depth.height() * 3);
 
     Region r = (Region) {
             .imin=0, .jmin=0, .kmin=0,
             .ni=(uint32_t)depth.width(), .nj=(uint32_t)depth.height(),
-            .nk=uint32_t(fmin(255, fmax(1, (shape->bounds.zmax -
-                                  shape->bounds.zmin) * scale)))
+            .nk=uint32_t(fmax(1, (shape->bounds.zmax -
+                                  shape->bounds.zmin) * scale))
     };
 
     build_arrays(&r, shape->bounds.xmin, shape->bounds.ymin, shape->bounds.zmin,
                      shape->bounds.xmax, shape->bounds.ymax, shape->bounds.zmax);
-    render8(shape->tree.get(), r, d8_rows, &halt_flag, &processEvents);
-    shaded8(shape->tree.get(), r, d8_rows, s8_rows, &halt_flag, &processEvents);
+    render16(shape->tree.get(), r, d16_rows, &halt_flag, &processEvents);
+    shaded8(shape->tree.get(), r, d16_rows, s8_rows, &halt_flag, &processEvents);
 
     free_arrays(&r);
 
@@ -68,7 +68,7 @@ void RenderImage::render(Shape *shape)
     {
         for (int i=0; i < depth.width(); ++i)
         {
-            uint8_t pix = d8_rows[j][i];
+            uint8_t pix = d16_rows[j][i] >> 8;
             uint8_t* norm = s8_rows[j][i];
             if (pix)
             {
@@ -82,8 +82,8 @@ void RenderImage::render(Shape *shape)
 
     delete [] s8;
     delete [] s8_rows;
-    delete [] d8;
-    delete [] d8_rows;
+    delete [] d16;
+    delete [] d16_rows;
 
 }
 


### PR DESCRIPTION
This PR improves normals in shaded rendering in two ways:

## Exact partial derivatives
We switch to calculating partial derivatives explicitly.  Previously, they were estimated, i.e. `d/dx` was found evaluating the f-rep at `x + epsilon`.  I've added a new file (`fab/tree/math/math_g.c`) that has closed-form partial derivatives for all of the basic math functions.

## 16-bit depth fields
We switch to using 16-bit depth fields (`render16` vs. `render8`) in `RenderImage`.  This makes the point-selection more accurate; the point whose normal we calculate is much closer to the model's surface.

Before:
![Before](https://cloud.githubusercontent.com/assets/745333/8021745/c1dddfb8-0c7a-11e5-96d3-e4165e7d6365.png)

After:
![After](https://cloud.githubusercontent.com/assets/745333/8021747/cd38eb8c-0c7a-11e5-986b-e4505131a0be.png)

