### PR TITLE
Improve shading

### DIFF
--- a/gl/shaded.frag
+++ b/gl/shaded.frag
@@ -22,7 +22,7 @@ vec4 shade(vec4 norm)
 
     if (flat == 1)
     {
-        a = a*0.7 + 0.3;
+        a = a*0.5 + 0.5;
         return vec4((a*light + (1-a)*dark), 1);
     }
     else

--- a/gl/shaded.frag
+++ b/gl/shaded.frag
@@ -8,6 +8,7 @@ uniform float zmin_local;
 uniform float dz_local;
 uniform float zmin_global;
 uniform float dz_global;
+uniform int flat;
 
 uniform vec3 color;
 
@@ -19,8 +20,16 @@ vec4 shade(vec4 norm)
     float a = dot(2 * (norm.xyz - vec3(0.5)), vec3(0.0, 0.0, 1.0));
     float b = dot(2 * (norm.xyz - vec3(0.5)), vec3(0.57, 0.57, 0.57));
 
-    return vec4((a*light + (1-a)*dark)*0.35 +
-                (b*light + (1-b)*dark)*0.65, 1);
+    if (flat == 1)
+    {
+        a = a*0.7 + 0.3;
+        return vec4((a*light + (1-a)*dark), 1);
+    }
+    else
+    {
+        return vec4((a*light + (1-a)*dark)*0.35 +
+                    (b*light + (1-b)*dark)*0.65, 1);
+    }
 }
 
 void main() {

--- a/gl/shaded.frag
+++ b/gl/shaded.frag
@@ -16,10 +16,10 @@ vec4 shade(vec4 norm)
     vec3 light = vec3(0.99 * color.r, 0.96 * color.g, 0.89 * color.b);
     vec3 dark = vec3(0.20 * color.r, 0.25 * color.g, 0.3 * color.b);
 
-    float a = dot(norm.xyz, vec3(0.57, 0.57, 0.57));
-    float b = dot(norm.xyz, vec3(-0.57, -0.57, 0.57));
+    float a = dot(2 * (norm.xyz - vec3(0.5)), vec3(0.0, 0.0, 1.0));
+    float b = dot(2 * (norm.xyz - vec3(0.5)), vec3(0.57, 0.57, 0.57));
 
-    return vec4((a*light + (1-a)*dark)*0.65 +
+    return vec4((a*light + (1-a)*dark)*0.35 +
                 (b*light + (1-b)*dark)*0.65, 1);
 }
 

--- a/src/fab/tree/render.c
+++ b/src/fab/tree/render.c
@@ -188,7 +188,7 @@ void shade_pixels8(unsigned count, float (*normals)[3],
     {
         for (int b=0; b < 3; ++b)
         {
-            out[js[a]][is[a]][b] = fabs(normals[a][b]) * 255;
+            out[js[a]][is[a]][b] = normals[a][b]*127 + 128;
         }
     }
 }

--- a/src/render/render_image.cpp
+++ b/src/render/render_image.cpp
@@ -16,7 +16,7 @@ RenderImage::RenderImage(Bounds b, QVector3D pos, float scale)
             (b.ymax - b.ymin) * scale,
             QImage::Format_RGB32),
       shaded(depth.width(), depth.height(), depth.format()),
-      halt_flag(0), color(255, 255, 255)
+      halt_flag(0), color(255, 255, 255), flat(false)
 {
     // Nothing to do here
     // (render() must be called explicity)
@@ -117,6 +117,6 @@ DepthImageItem* RenderImage::addToViewport(Viewport* viewport)
             QVector3D(bounds.xmax - bounds.xmin,
                       bounds.ymax - bounds.ymin,
                       bounds.zmax - bounds.zmin),
-            depth, shaded, color, viewport);
+            depth, shaded, color, flat, viewport);
 }
 

--- a/src/render/render_image.h
+++ b/src/render/render_image.h
@@ -32,6 +32,8 @@ public:
 
     void setColor(QColor color_) { color = color_; }
 
+    void setFlat(bool f) { flat = f; }
+
 public slots:
     void halt();
 
@@ -55,6 +57,7 @@ protected:
     int halt_flag;
 
     QColor color;
+    bool flat;
 
     friend class RenderTask;
 };

--- a/src/render/render_task.cpp
+++ b/src/render/render_task.cpp
@@ -138,8 +138,9 @@ void RenderTask::render2d(Shape s)
         image->setColor(QColor(s.r, s.g, s.b));
 
     image->setNormals(
-        sqrt(pow(matrix(0,2),2) + pow(matrix(1,2),2)),
-        matrix(2,2));
+            sqrt(pow(matrix(0,2),2) + pow(matrix(1,2),2)),
+            fabs(matrix(2,2)));
+    image->setFlat(true);
 }
 
 Transform RenderTask::getTransform(QMatrix4x4 m)

--- a/src/ui/viewport/depth_image.cpp
+++ b/src/ui/viewport/depth_image.cpp
@@ -151,6 +151,7 @@ void DepthImageItem::loadSharedShaderVariables(QOpenGLShaderProgram* shader)
     glUniform1f(shader->uniformLocation("zmin_local"), zmin);
     glUniform1f(shader->uniformLocation("dz_global"), dz_global);
     glUniform1f(shader->uniformLocation("zmin_global"), zmin_global);
+    glUniform1i(shader->uniformLocation("flat"), flat);
 
     glUniform3f(shader->uniformLocation("color"),
                 color.redF(), color.greenF(), color.blueF());

--- a/src/ui/viewport/depth_image.cpp
+++ b/src/ui/viewport/depth_image.cpp
@@ -20,9 +20,9 @@
 
 DepthImageItem::DepthImageItem(QVector3D pos, QVector3D size,
                                QImage depth, QImage shaded, QColor color,
-                               Viewport* viewport)
+                               bool flat, Viewport* viewport)
     : QObject(viewport), pos(pos), size(size), depth(depth), shaded(shaded),
-      color(color), viewport(viewport)
+      color(color), flat(flat), viewport(viewport)
 {
     initializeGL();
 

--- a/src/ui/viewport/depth_image.h
+++ b/src/ui/viewport/depth_image.h
@@ -17,7 +17,7 @@ class DepthImageItem : public QObject, protected QOpenGLFunctions
 public:
     DepthImageItem(QVector3D pos, QVector3D size,
                    QImage depth, QImage shaded, QColor color,
-                   Viewport* viewport);
+                   bool flat, Viewport* viewport);
     ~DepthImageItem();
 
     /*
@@ -46,6 +46,7 @@ protected:
     QImage depth;
     QImage shaded;
     QColor color;
+    bool flat;
 
     QPointer<Viewport> viewport;
 


### PR DESCRIPTION
Make light sources come from an angle, so that (for example) looking at a cone from above isn't all the same color.  Minor tweaks to the 2D rendering pipeline: they're now flagged as `flat`, which causes slightly different behavior in the fragment shader.