### PR TITLE
New parsing engine; new infix syntax support; lots of extra debugging…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,15 @@ build-*/*
 build
 
 *.sublime-workspace
+
+src/fab/tree/v2syntax.lemon.cpp
+
+src/fab/tree/v2syntax.lemon.hpp
+
+src/fab/tree/v2syntax.yy.cpp
+
+src/fab/tree/v2syntax.yy.hpp
+
+.cproject
+
+.project

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -4,6 +4,8 @@ Requirements
 - [Python 3](https://www.python.org/)
 - [Boost.Python](http://www.boost.org/doc/libs/1_57_0/libs/python/doc/index.html) (linked against Python 3)
 - [`libpng`](http://www.libpng.org/pub/png/libpng.html)
+- [Lemon](http://www.hwaci.com/sw/lemon/)
+- [Flex](http://flex.sourceforge.net)
 
 Mac OS X
 --------
@@ -13,6 +15,8 @@ brew install libpng
 brew install python3
 brew install --with-python3 boost-python
 brew install qt5
+brew install lemon
+brew install flex
 
 git clone https://github.com/mkeeter/antimony
 cd antimony
@@ -27,7 +31,7 @@ open antimony.app
 
 Linux
 -----
-Tested on a clean Xubuntu 14.04 virtual machine:  
+Tested on a clean Xubuntu 14.04 virtual machine:
 Install [Qt 5.4](http://www.qt.io/download-open-source/#section-3), then run
 ```
 sudo apt-get install build-essential
@@ -35,6 +39,8 @@ sudo apt-get install libpng-dev
 sudo apt-get install python3-dev
 sudo apt-get install libboost-all-dev
 sudo apt-get install libgl1-mesa-dev
+sudo apt-get install lemon
+sudo apt-get install flex
 
 git clone https://github.com/mkeeter/antimony
 cd antimony
@@ -49,7 +55,7 @@ make -j8
 
 You can use `make install`, or set up a symlink to run `antimony` from outside the build directory:
 ```
-ln -s ~/antimony/build/antimony /usr/local/bin/antimony 
+ln -s ~/antimony/build/antimony /usr/local/bin/antimony
 ```
 
 ### Caveats

--- a/py/fab/shapes.py
+++ b/py/fab/shapes.py
@@ -414,7 +414,7 @@ def scale_z_r(part, x0, y0, z0, r0, s0, r1, s1):
 def extrude_z(part, zmin, zmax):
     # max(part, max(zmin-Z, Z-zmax))
     return Shape(
-            'am  f1%sa-f%gZ-Zf%g' % (part.math, zmin, zmax),
+            'am__f1%sa-f%gZ-Zf%g' % (part.math, zmin, zmax),
             part.bounds.xmin, part.bounds.ymin, zmin,
             part.bounds.xmax, part.bounds.ymax, zmax)
 
@@ -579,8 +579,7 @@ def cylinder_y(x, ymin, ymax, z, r):
       x-r, ymin, z-r, x+r, ymax,z+r)
 
 def sphere(x, y, z, r):
-    return Shape(
-            '-r++q%sq%sq%sf%g' % (('-Xf%g' % x) if x else 'X',
+    return Shape('-r++q%sq%sq%sf%g' % (('-Xf%g' % x) if x else 'X',
                                   ('-Yf%g' % y) if y else 'Y',
                                   ('-Zf%g' % z) if z else 'Z',
                                   r),
@@ -1478,4 +1477,3 @@ _widths['?'] = 0.55
 _glyphs['?'] = shape
 
 del shape
-

--- a/qt/fab.pri
+++ b/qt/fab.pri
@@ -1,4 +1,5 @@
 SOURCES += \
+    ../src/fab/tree/v2parser.cpp \
     ../src/fab/tree/eval.c \
     ../src/fab/tree/render.c \
     ../src/fab/tree/tree.c \
@@ -49,6 +50,11 @@ HEADERS += \
     ../src/fab/fab.h \
     ../src/fab/types/bounds.h \
     ../src/fab/types/transform.h
+
+include(flex.pri)
+include(lemon.pri)
+FLEXSOURCES = ../src/fab/tree/v2syntax.l
+LEMONSOURCES = ../src/fab/tree/v2syntax.y
 
 INCLUDEPATH += ../src/fab
 INCLUDEPATH += ../src

--- a/qt/flex.pri
+++ b/qt/flex.pri
@@ -1,0 +1,8 @@
+flex.name = Flex ${QMAKE_FILE_IN}
+flex.input = FLEXSOURCES
+flex.output = ${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}.yy.cpp
+flex.commands = flex --outfile=${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}.yy.cpp --header-file=${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}.yy.hpp  ${QMAKE_FILE_IN}
+flex.CONFIG += target_predeps
+flex.variable_out = GENERATED_SOURCES
+silent:flex.commands = @echo Lex ${QMAKE_FILE_IN} && $$flex.commands
+QMAKE_EXTRA_COMPILERS += flex

--- a/qt/lemon.pri
+++ b/qt/lemon.pri
@@ -1,0 +1,9 @@
+lemon.name = lemon ${QMAKE_FILE_IN}
+lemon.input = LEMONSOURCES
+lemon.output = ${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}.lemon.cpp
+lemon.commands = lemon -q -c -s ${QMAKE_FILE_IN} && mv ${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}.c ${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}.lemon.cpp && mv ${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}.h ${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}.lemon.hpp
+lemon.CONFIG += target_predeps
+lemon.variable_out = GENERATED_SOURCES
+silent:lemon.commands = @echo lemon -q -c -s ${QMAKE_FILE_IN} && mv ${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}.c ${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}.lemon.cpp && mv ${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}.h ${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}.lemon.hpp
+QMAKE_EXTRA_COMPILERS += lemon
+QMAKE_CLEAN += ${QMAKE_FILE_PATH}/${QMAKE_FILE_BASE}.lemon.hpp

--- a/src/fab/tree/node/printers.c
+++ b/src/fab/tree/node/printers.c
@@ -3,11 +3,17 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
+static void base_p(Node* n, FILE* f)
+{
+    fprintf(f, ANSI_COLOR_GRAY "[rank=%i; flags=%u]" ANSI_COLOR_RESET, n->rank, n->flags);
+}
+
 static void add_p(Node* n, FILE* f)
 {
     fprintf(f, "(");
     fprint_node(n->lhs, f);
     fprintf(f, "+");
+    base_p(n, f);
     fprint_node(n->rhs, f);
     fprintf(f, ")");
 }
@@ -17,6 +23,7 @@ static void sub_p(Node* n, FILE* f)
     fprintf(f, "(");
     fprint_node(n->lhs, f);
     fprintf(f, "-");
+    base_p(n, f);
     fprint_node(n->rhs, f);
     fprintf(f, ")");
 }
@@ -26,6 +33,7 @@ static void mul_p(Node* n, FILE* f)
     fprintf(f, "(");
     fprint_node(n->lhs, f);
     fprintf(f, "*");
+    base_p(n, f);
     fprint_node(n->rhs, f);
     fprintf(f, ")");
 }
@@ -35,13 +43,16 @@ static void div_p(Node* n, FILE* f)
     fprintf(f, "(");
     fprint_node(n->lhs, f);
     fprintf(f, "/");
+    base_p(n, f);
     fprint_node(n->rhs, f);
     fprintf(f, ")");
 }
 
 static void min_p(Node* n, FILE* f)
 {
-    fprintf(f, "min(");
+    fprintf(f, "min");
+    base_p(n, f);
+    fprintf(f, "(");
     fprint_node(n->lhs, f);
     fprintf(f, ", ");
     fprint_node(n->rhs, f);
@@ -50,7 +61,9 @@ static void min_p(Node* n, FILE* f)
 
 static void max_p(Node* n, FILE* f)
 {
-    fprintf(f, "max(");
+    fprintf(f, "max");
+    base_p(n, f);
+    fprintf(f, "(");
     fprint_node(n->lhs, f);
     fprintf(f, ", ");
     fprint_node(n->rhs, f);
@@ -59,7 +72,9 @@ static void max_p(Node* n, FILE* f)
 
 static void pow_p(Node* n, FILE* f)
 {
-    fprintf(f, "pow(");
+    fprintf(f, "pow");
+    base_p(n, f);
+    fprintf(f, "(");
     fprint_node(n->lhs, f);
     fprintf(f, ", ");
     fprint_node(n->rhs, f);
@@ -70,56 +85,72 @@ static void pow_p(Node* n, FILE* f)
 
 static void square_p(Node* n, FILE* f)
 {
-    fprintf(f, "pow(");
+    fprintf(f, "sqr");
+    base_p(n, f);
+    fprintf(f, "(");
     fprint_node(n->lhs, f);
-    fprintf(f, ", 2)");
+    fprintf(f, ")");
 }
 
 static void sqrt_p(Node* n, FILE* f)
 {
-    fprintf(f, "sqrt(");
+    fprintf(f, "sqrt");
+    base_p(n, f);
+    fprintf(f, "(");
     fprint_node(n->lhs, f);
     fprintf(f, ")");
 }
 
 static void sin_p(Node* n, FILE* f)
 {
-    fprintf(f, "sin(");
+    fprintf(f, "sin");
+    base_p(n, f);
+    fprintf(f, "(");
     fprint_node(n->lhs, f);
     fprintf(f, ")");
 }
 
 static void cos_p(Node* n, FILE* f)
 {
-    fprintf(f, "cos(");
+    fprintf(f, "cos");
+    base_p(n, f);
+    fprintf(f, "(");
     fprint_node(n->lhs, f);
     fprintf(f, ")");
 }
 
 static void tan_p(Node* n, FILE* f)
 {
-    fprintf(f, "tan(");
+    fprintf(f, "tan");
+    base_p(n, f);
+    fprintf(f, "(");
     fprint_node(n->lhs, f);
     fprintf(f, ")");
 }
 
 static void asin_p(Node* n, FILE* f)
 {
-    fprintf(f, "asin(");
+    fprintf(f, "asin");
+    base_p(n, f);
+    fprintf(f, "(");
     fprint_node(n->lhs, f);
     fprintf(f, ")");
 }
 
 static void acos_p(Node* n, FILE* f)
 {
-    fprintf(f, "acos(");
+    fprintf(f, "acos");
+    base_p(n, f);
+    fprintf(f, "(");
     fprint_node(n->lhs, f);
     fprintf(f, ")");
 }
 
 static void atan_p(Node* n, FILE* f)
 {
-    fprintf(f, "atan(");
+    fprintf(f, "atan");
+    base_p(n, f);
+    fprintf(f, "(");
     fprint_node(n->lhs, f);
     fprintf(f, ")");
 }
@@ -127,12 +158,15 @@ static void atan_p(Node* n, FILE* f)
 static void neg_p(Node* n, FILE* f)
 {
     fprintf(f, "-");
+    base_p(n, f);
     fprint_node(n->lhs, f);
 }
 
 static void exp_p(Node* n, FILE* f)
 {
-    fprintf(f, "exp(");
+    fprintf(f, "exp");
+    base_p(n, f);
+    fprintf(f, "(");
     fprint_node(n->lhs, f);
     fprintf(f, ")");
 }
@@ -200,6 +234,6 @@ void fprint_node(Node* n, FILE* f)
         case OP_Y:      Y_p(n, f); break;
         case OP_Z:      Z_p(n, f); break;
         default:
-            fprintf(f, "Unknown opcode!\n");
+            fprintf(f, "Unknown opcode!: %i\n", n->opcode);
     }
 }

--- a/src/fab/tree/node/printers.h
+++ b/src/fab/tree/node/printers.h
@@ -3,6 +3,16 @@
 
 #include <stdio.h>
 
+#define ANSI_COLOR_GRAY		"\x1b[30;1m"
+#define ANSI_COLOR_RED		"\x1b[31m"
+#define ANSI_COLOR_GREEN	"\x1b[32m"
+#define ANSI_COLOR_YELLOW	"\x1b[33m"
+#define ANSI_COLOR_BLUE		"\x1b[34m"
+#define ANSI_COLOR_MAGENTA 	"\x1b[35m"
+#define ANSI_COLOR_CYAN 	"\x1b[36m"
+#define ANSI_COLOR_RESET 	"\x1b[0m"
+
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/fab/tree/parser.h
+++ b/src/fab/tree/parser.h
@@ -1,5 +1,8 @@
 #ifndef PARSER_H
 #define PARSER_H
+#include "tree/tree.h"
+#include "tree/node/node.h"
+#include "tree/node/opcodes.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -16,5 +19,21 @@ struct MathTree_* parse(const char* input);
 #ifdef __cplusplus
 }
 #endif
+
+
+/* Linked list of Nodes */
+typedef struct NodeList_
+{
+    Node* node;
+    struct NodeList_* next;
+} NodeList;
+
+/* Cache storing multiple lists of NodeLists */
+typedef struct NodeCache_
+{
+    int levels;
+    NodeList* (*nodes)[LAST_OP]; // indexed by [level][opcode]
+    NodeList* constants;
+} NodeCache;
 
 #endif

--- a/src/fab/tree/v2parser.cpp
+++ b/src/fab/tree/v2parser.cpp
@@ -1,0 +1,84 @@
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <stdbool.h>
+
+#include "v2parser.hpp"
+#include "v2syntax.lemon.hpp"
+#include "v2syntax.yy.hpp"
+#include "tree/tree.h"
+#include "tree/parser.h"
+#include "tree/node/node.h"
+#include "tree/node/opcodes.h"
+#include "tree/node/printers.h"
+
+#define ANSI_COLOR_RED		"\x1b[31m"
+#define ANSI_COLOR_GREEN	"\x1b[32m"
+#define ANSI_COLOR_YELLOW	"\x1b[33m"
+#define ANSI_COLOR_BLUE		"\x1b[34m"
+#define ANSI_COLOR_MAGENTA 	"\x1b[35m"
+#define ANSI_COLOR_CYAN 	"\x1b[36m"
+#define ANSI_COLOR_RESET 	"\x1b[0m"
+
+using namespace std;
+
+extern "C"
+{
+	bool v2parse(Node **result, const char* input, Node* X, Node* Y, Node *Z, NodeCache* cache);
+}
+
+void* v2ParseAlloc(void* (*allocProc)(size_t));
+void v2Parse(void* parser, int token, const char*, Env* environment);
+void v2ParseFree(void* parser, void(*freeProc)(void*));
+void v2ParseTrace(FILE*, char*);
+
+bool v2parse(Node **result, const char* input, Node* X, Node* Y, Node *Z, NodeCache* cache)
+{
+	printf(ANSI_COLOR_BLUE "Parsing input:" ANSI_COLOR_RESET " \t'%s'\n");
+	//v2ParseTrace(stdout, "\t" ANSI_COLOR_YELLOW "\tParse trace:\t" ANSI_COLOR_RESET); //DEBUG
+
+	Env* locals = (Env*) malloc(sizeof(Env));
+	locals->valid = true;
+	locals->head = NULL;
+	locals->Xnode = X;
+	locals->Ynode = Y;
+	locals->Znode = Z;
+	locals->cache = cache;
+	locals->nodestack = new std::stack<Node*>();
+
+
+	yyscan_t scanner;
+	yylex_init(&scanner);
+	YY_BUFFER_STATE bufferState = yy_scan_string(input, scanner);
+	void *parser = v2ParseAlloc(malloc);
+
+	char *text;
+	int lexCode;
+
+	do {
+		lexCode = yylex(scanner);
+		text = yyget_text(scanner);
+		//printf("\tlex trace:\tcode: %i\t text: '%s'\n", lexCode, text); //DEBUG
+		v2Parse(parser, lexCode, text, locals);
+	} while (lexCode > 0 &&  locals->valid);
+
+
+	if (-1 == lexCode || !locals->valid) {
+		printf(ANSI_COLOR_RED "Parse failure on input of:" ANSI_COLOR_RESET " '%s'\n", input);
+		return false;
+	}
+
+	*result = locals->head;
+
+	printf(ANSI_COLOR_GREEN "Parse success:\t" ANSI_COLOR_RESET);
+	print_node(*result);
+	printf("\n");
+
+	yy_delete_buffer(bufferState, scanner);
+	yylex_destroy(scanner);
+	v2ParseFree(parser, free);
+	free(locals->nodestack);
+	free(locals);
+
+	return true;
+}

--- a/src/fab/tree/v2parser.cpp
+++ b/src/fab/tree/v2parser.cpp
@@ -34,8 +34,10 @@ void v2ParseTrace(FILE*, char*);
 
 bool v2parse(Node **result, const char* input, Node* X, Node* Y, Node *Z, NodeCache* cache)
 {
-	printf(ANSI_COLOR_BLUE "Parsing input:" ANSI_COLOR_RESET " \t'%s'\n");
-	//v2ParseTrace(stdout, "\t" ANSI_COLOR_YELLOW "\tParse trace:\t" ANSI_COLOR_RESET); //DEBUG
+	#ifdef PARSEDEBUG
+		printf(ANSI_COLOR_BLUE "Parsing input:" ANSI_COLOR_RESET " \t'%s'\n");
+		v2ParseTrace(stdout, "\t" ANSI_COLOR_YELLOW "\tParse trace:\t" ANSI_COLOR_RESET);
+	#endif
 
 	Env* locals = (Env*) malloc(sizeof(Env));
 	locals->valid = true;
@@ -58,7 +60,6 @@ bool v2parse(Node **result, const char* input, Node* X, Node* Y, Node *Z, NodeCa
 	do {
 		lexCode = yylex(scanner);
 		text = yyget_text(scanner);
-		//printf("\tlex trace:\tcode: %i\t text: '%s'\n", lexCode, text); //DEBUG
 		v2Parse(parser, lexCode, text, locals);
 	} while (lexCode > 0 &&  locals->valid);
 
@@ -70,9 +71,11 @@ bool v2parse(Node **result, const char* input, Node* X, Node* Y, Node *Z, NodeCa
 
 	*result = locals->head;
 
-	printf(ANSI_COLOR_GREEN "Parse success:\t" ANSI_COLOR_RESET);
-	print_node(*result);
-	printf("\n");
+	#ifdef PARSEDEBUG
+		printf(ANSI_COLOR_GREEN "Parse success:\t" ANSI_COLOR_RESET);
+		print_node(*result);
+		printf("\n");
+	#endif
 
 	yy_delete_buffer(bufferState, scanner);
 	yylex_destroy(scanner);

--- a/src/fab/tree/v2parser.hpp
+++ b/src/fab/tree/v2parser.hpp
@@ -1,0 +1,17 @@
+#include "tree/tree.h"
+#include "tree/parser.h"
+#include "tree/node/node.h"
+#include "tree/node/opcodes.h"
+#include <stack>
+
+typedef struct env_
+{
+	bool valid;
+	Node* head;
+	Node* Xnode;
+	Node* Ynode;
+	Node* Znode;
+	NodeCache* cache;
+	Node *tempX, *tempY, *tempZ;
+	std::stack <Node*>	*nodestack;
+} Env;

--- a/src/fab/tree/v2syntax.l
+++ b/src/fab/tree/v2syntax.l
@@ -1,0 +1,111 @@
+
+%{
+	#include <math.h>
+	#include <stdlib.h>
+	#include "v2syntax.lemon.hpp"
+	#include "v2parser.hpp"
+%}
+
+%option reentrant
+%option noyywrap
+
+%x V2
+
+white				[ \t]+
+digit				[0-9]
+integer 			{digit}+
+exponent			[eE][+-]?{integer}
+real				{integer}*("."{digit}+)?{exponent}?
+
+%%
+
+{white}				;
+{real}				return TOKEN_V1FLOAT;
+"+"				return TOKEN_V1PLUS;
+"-"				return TOKEN_V1MINUS;
+"*"				return TOKEN_V1MUL;
+"/"				return TOKEN_V1DIV;
+"i"				return TOKEN_V1MIN;
+"a"				return TOKEN_V1MAX;
+"p"				return TOKEN_V1POW;
+"s"				return TOKEN_V1SIN;
+"c"				return TOKEN_V1COS;
+"t"				return TOKEN_V1TAN;
+"S"				return TOKEN_V1ASIN;
+"C"				return TOKEN_V1ACOS;
+"T"				return TOKEN_V1ATAN;
+"b"				return TOKEN_V1ABS;
+"q"				return TOKEN_V1SQUARE;
+"r"				return TOKEN_V1SQRT;
+"n"				return TOKEN_V1NEG;
+"x"				return TOKEN_V1EXP;
+"m"				return TOKEN_V1MAP;
+"_"				return TOKEN_V1SKIP;
+
+"X"				return TOKEN_V1X;
+"Y"				return TOKEN_V1Y;
+"Z"				return TOKEN_V1Z;
+
+"="				{
+					BEGIN V2;
+					return TOKEN_EQUAL;
+				}
+
+"f"				return TOKEN_CONSTANT;
+"]"				{
+					BEGIN V2;
+					return TOKEN_RBRACKET;
+				}
+
+
+<V2>{
+	{real} 			return TOKEN_FLOAT;
+	{white}			;
+
+	"+"			return TOKEN_PLUS;
+	"-"			return TOKEN_MINUS;
+	"*"			return TOKEN_MUL;
+	"/"			return TOKEN_DIV;
+	"**"			return TOKEN_DOUBLESTAR;
+
+	"min"			return TOKEN_MIN;
+	"max"			return TOKEN_MAX;
+	"pow"			return TOKEN_POW;
+	"sin"			return TOKEN_SIN;
+	"cos" 			return TOKEN_COS;
+	"tan"			return TOKEN_TAN;
+	"asin"			return TOKEN_ASIN;
+	"acos"			return TOKEN_ACOS;
+	"atan"			return TOKEN_ATAN;
+	"abs"			return TOKEN_ABS;
+	"sqrt"			return TOKEN_SQRT;
+	"exp"			return TOKEN_EXP;
+
+	"map"			return TOKEN_MAP;
+
+	"X"			return TOKEN_X;
+	"Y"			return TOKEN_Y;
+	"Z"			return TOKEN_Z;
+
+	","			return TOKEN_COMMA;
+	"("			return TOKEN_LPAREN;
+	")"			return TOKEN_RPAREN;
+
+	"["			{
+					BEGIN INITIAL;
+					return TOKEN_LBRACKET;
+				}
+
+	"{"			return TOKEN_LBRACE;
+	"}"			return TOKEN_RBRACE;
+
+	"_"			return TOKEN_SKIP;
+
+	";"			{
+					BEGIN INITIAL;
+					return TOKEN_SEMICOLON;
+				}
+}
+
+
+%%

--- a/src/fab/tree/v2syntax.y
+++ b/src/fab/tree/v2syntax.y
@@ -1,0 +1,164 @@
+%include {
+	#include <math.h>
+	#include <cassert>
+	#include <iostream>
+	#include "v2parser.hpp"
+
+	extern "C"
+	{
+		Node* get_cached_node(NodeCache* const cache, Node* const n);
+	}
+
+	#define CACHED(n) get_cached_node(environment->cache, n)
+	//#define CACHED(n) n
+}
+
+%name v2Parse
+%extra_argument {Env* environment}
+
+%token_type {const char*}
+%token_prefix TOKEN_
+
+%type v1_expr {Node* }
+%type v1_assignment_expr {Node* }
+%type expr {Node* }
+%type assignment_expr {Node* }
+
+%left PLUS MINUS.
+%left MUL DIV.
+%right DOUBLESTAR.
+%right UMINUS.
+
+%syntax_error
+{
+	environment->valid = false;
+	int n = sizeof(yyTokenName) / sizeof(yyTokenName[0]);
+	for (int i = 0; i < n; ++i) {
+		int a = yy_find_shift_action(yypParser, (YYCODETYPE)i);
+		if (a < YYNSTATE + YYNRULE) {
+		printf("possible token: %s\n", yyTokenName[i]);
+		}
+	}
+}
+
+
+program 	::= v1_expr(E).						{	environment->head = E; 	}
+
+v1_assignment_expr(E) 	::= v1_expr(O).			{	E = O;   			}
+v1_assignment_expr(E) 	::= V1SKIP.    			{	E = NULL;			}
+
+v1_assignment_exprs 		::=  v1_assignment_expr(I) v1_assignment_expr(J) v1_assignment_expr(K).
+			{
+				environment->nodestack->push(environment->Xnode);
+				environment->nodestack->push(environment->Ynode);
+				environment->nodestack->push(environment->Znode);
+
+				environment->tempX = I ? CACHED(I) : environment->Xnode;
+				environment->tempY = J ? CACHED(J) : environment->Ynode;
+				environment->tempZ = K ? CACHED(K) : environment->Znode;
+
+				environment->Xnode = environment->tempX;
+				environment->Ynode = environment->tempY;
+				environment->Znode = environment->tempZ;
+			}
+
+v1_expr(E) 			::= V1MAP v1_assignment_exprs v1_expr(O).
+			{
+				E = O;
+				environment->Znode = environment->nodestack->top();
+				environment->nodestack->pop();
+				environment->Ynode = environment->nodestack->top();
+				environment->nodestack->pop();
+				environment->Xnode = environment->nodestack->top();
+				environment->nodestack->pop();
+			}
+
+v1_expr(E)	::= V1PLUS v1_expr(L) v1_expr(R). 			{	E = CACHED(add_n(L, R)); 	}
+v1_expr(E)	::= V1MINUS v1_expr(L) v1_expr(R).			{	E = CACHED(sub_n(L, R)); 	}
+v1_expr(E)	::= V1MUL v1_expr(L) v1_expr(R).  			{	E = CACHED(mul_n(L, R)); 	}
+v1_expr(E)	::= V1DIV v1_expr(L) v1_expr(R).  			{	E = CACHED(div_n(L, R)); 	}
+v1_expr(E)	::= V1MIN v1_expr(L) v1_expr(R).  			{	E = CACHED(min_n(L, R)); 	}
+v1_expr(E)	::= V1MAX v1_expr(L) v1_expr(R).  			{	E = CACHED(max_n(L, R)); 	}
+v1_expr(E)	::= V1POW v1_expr(L) v1_expr(R).  			{	E = CACHED(pow_n(L, R)); 	}
+
+v1_expr(E)	::= V1SIN v1_expr(O).   				{	E = CACHED(sin_n(O)); 	}
+v1_expr(E)	::= V1COS v1_expr(O).   				{	E = CACHED(cos_n(O)); 	}
+v1_expr(E)	::= V1TAN v1_expr(O).   				{	E = CACHED(tan_n(O)); 	}
+v1_expr(E)	::= V1ASIN v1_expr(O).  				{	E = CACHED(asin_n(O)); 	}
+v1_expr(E)	::= V1ACOS v1_expr(O).  				{	E = CACHED(acos_n(O)); 	}
+v1_expr(E)	::= V1ATAN v1_expr(O).  				{	E = CACHED(atan_n(O)); 	}
+v1_expr(E)	::= V1ABS v1_expr(O).   				{	E = CACHED(abs_n(O)); 	}
+v1_expr(E)	::= V1SQUARE v1_expr(O).				{	E = CACHED(square_n(O)); 	}
+v1_expr(E)	::= V1SQRT v1_expr(O).  				{	E = CACHED(sqrt_n(O)); 	}
+v1_expr(E)	::= V1NEG v1_expr(O).   				{	E = CACHED(neg_n(O)); 	}
+v1_expr(E)	::= V1EXP v1_expr(O).   				{	E = CACHED(exp_n(O)); 	}
+v1_expr(E)	::= CONSTANT V1MINUS V1FLOAT(F).		{	E = CACHED(constant_n(-atof(F))); 	}
+v1_expr(E)	::= CONSTANT V1FLOAT(F).				{	E = CACHED(constant_n(atof(F))); 	}
+
+v1_expr(E)	::= V1X.						{	E = CACHED(environment->Xnode); 	}
+v1_expr(E)	::= V1Y.						{	E = CACHED(environment->Ynode); 	}
+v1_expr(E)	::= V1Z.						{	E = CACHED(environment->Znode); 	}
+
+v1_expr(E)	::= EQUAL expr(V) SEMICOLON.			{	E = V; }
+
+
+
+expr(E) 	::= LBRACKET v1_expr(V) RBRACKET.		{	E = V; }
+expr(E) 	::= LPAREN expr(O) RPAREN.       		 	{	E = O; }
+
+
+
+
+expr(E) 	::= FLOAT(F).						{	E = CACHED(constant_n(atof(F))); 	}
+expr(E) 	::= X.       						{	E = CACHED(environment->Xnode); 	}
+expr(E) 	::= Y.       						{	E = CACHED(environment->Ynode); 	}
+expr(E) 	::= Z.       						{	E = CACHED(environment->Znode); 	}
+
+expr(E)		::= expr(L) PLUS expr(R).				{	E = CACHED(add_n(L, R)); 	}
+expr(E)		::= expr(L) MINUS expr(R).				{	E = CACHED(sub_n(L, R)); 	}
+expr(E)		::= expr(L) MUL expr(R).				{	E = CACHED(mul_n(L, R)); 	}
+expr(E)		::= expr(L) DIV expr(R).				{	E = CACHED(div_n(L, R)); 	}
+expr(E)		::= expr(L) DOUBLESTAR expr(R).			{	E = CACHED(pow_n(L, R)); 	}
+
+expr(E)		::= MIN LPAREN expr(L) COMMA expr(R) RPAREN.		{	E = CACHED(min_n(L, R)); 	}
+expr(E)		::= MAX LPAREN expr(L) COMMA expr(R) RPAREN.	{	E = CACHED(max_n(L, R)); 	}
+expr(E)		::= POW LPAREN expr(L) COMMA expr(R) RPAREN.	{	E = CACHED(pow_n(L, R)); 	}
+
+expr(E)		::= SIN LPAREN expr(O) RPAREN.			{	E = CACHED(sin_n(O)); 	}
+expr(E)		::= COS LPAREN expr(O) RPAREN.			{	E = CACHED(cos_n(O)); 	}
+expr(E)		::= TAN LPAREN expr(O) RPAREN.			{	E = CACHED(tan_n(O)); 	}
+expr(E)		::= ASIN LPAREN expr(O) RPAREN.			{	E = CACHED(asin_n(O)); 	}
+expr(E)		::= ACOS LPAREN expr(O) RPAREN.		{	E = CACHED(acos_n(O)); 	}
+expr(E)		::= ATAN LPAREN expr(O) RPAREN.		{	E = CACHED(atan_n(O)); 	}
+expr(E)		::= ABS LPAREN expr(O) RPAREN.			{	E = CACHED(abs_n(O)); 	}
+expr(E)		::= SQRT LPAREN expr(O) RPAREN.		{	E = CACHED(sqrt_n(O)); 	}
+expr(E)		::= MINUS expr(O). [UMINUS]			{	E = CACHED(neg_n(O)); 	}
+expr(E)		::= EXP LPAREN expr(O) RPAREN.			{	E = CACHED(exp_n(O)); 	}
+
+expr(E)		::= MAP assignment_exprs LBRACE expr(O) RBRACE.
+			{
+				E = O;
+				environment->Znode = environment->nodestack->top();
+				environment->nodestack->pop();
+				environment->Ynode = environment->nodestack->top();
+				environment->nodestack->pop();
+				environment->Xnode = environment->nodestack->top();
+				environment->nodestack->pop();
+			}
+
+assignment_expr(E) 	::= expr(O).					{ 	E = O; 		}
+assignment_expr(E) 	::= SKIP.  					{ 	E = NULL; 	}
+assignment_exprs ::=  LPAREN assignment_expr(I) COMMA assignment_expr(J) COMMA assignment_expr(K) RPAREN.
+			{
+				environment->nodestack->push(environment->Xnode);
+				environment->nodestack->push(environment->Ynode);
+				environment->nodestack->push(environment->Znode);
+
+				environment->tempX = I ? CACHED(I) : environment->Xnode;
+				environment->tempY = J ? CACHED(J) : environment->Ynode;
+				environment->tempZ = K ? CACHED(K) : environment->Znode;
+
+				environment->Xnode = environment->tempX;
+				environment->Ynode = environment->tempY;
+				environment->Znode = environment->tempZ;
+			}

--- a/src/fab/types/shape.cpp
+++ b/src/fab/types/shape.cpp
@@ -70,9 +70,9 @@ Shape::Shape(std::string math, Bounds bounds)
 
 Shape Shape::map(Transform t) const
 {
-    return Shape("m" + (t.x_forward.length() ? t.x_forward : " ")
-                     + (t.y_forward.length() ? t.y_forward : " ")
-                     + (t.z_forward.length() ? t.z_forward : " ") + math,
+    return Shape("m" + (t.x_forward.length() ? t.x_forward : "_")
+                     + (t.y_forward.length() ? t.y_forward : "_")
+                     + (t.z_forward.length() ? t.z_forward : "_") + math,
                  bounds.map(t));
 }
 


### PR DESCRIPTION
Pull request includes new parsing engine for existing syntax, with one modification: the map operator now expects `_` instead of a space for coordinate values that are to be kept as-is for the expression evaluation.

External dependencies added are lemon and flex.  (`brew install lemon flex`).

Also includes support for experimental infix syntax. This is not used for any of the defined nodes, but can be accessed through the function nodes  Infix mode is activated by `=` and terminated with `;`.  For example, the sphere equation `-r++qXqYqZf1` can instead be written as `= sqrt(X**2 + Y**2 + Z**2) - 1;`.  For places where you are using string interpolation to build up an expression, you can use brackets to ensure that the contents interpolated into the string are processed using the prefix grammar.  For example, `= sqrt( [q-Xf2] + Y**2 + Z**2) - 1;` shows how you can mix the old prefix notation in with the infix notation.  The map operator is now `map (Xexpr, Yexpr, Zexpr) {expr_to_eval}`.  If you want to skip any of the coordinates, just use `_`.  E.g., `= map(X*2, Y*2, _) { sqrt(X**2 + Y**2 + Z**2) - 1 };`  
