### PR TITLE
Arctan2

### DIFF
--- a/lib/fab/inc/fab/tree/math/math_f.h
+++ b/lib/fab/inc/fab/tree/math/math_f.h
@@ -34,6 +34,7 @@ float tan_f(float A);
 float asin_f(float A);
 float acos_f(float A);
 float atan_f(float A);
+float atan2_f(float A, float B);
 float neg_f(float A);
 float exp_f(float A);
 

--- a/lib/fab/inc/fab/tree/math/math_g.h
+++ b/lib/fab/inc/fab/tree/math/math_g.h
@@ -32,6 +32,8 @@ derivative* max_g(const derivative* A, const derivative* B, derivative* R, int c
 
 derivative* pow_g(const derivative* A, const derivative* B, derivative* R, int c);
 
+derivative* atan2_g(const derivative* A, const derivative* B, derivative* R, int c);
+
 // Unary functions
 derivative* abs_g(const derivative* A, derivative* R, int c);
 derivative* square_g(const derivative* A, derivative* R, int c);

--- a/lib/fab/inc/fab/tree/math/math_i.h
+++ b/lib/fab/inc/fab/tree/math/math_i.h
@@ -26,6 +26,8 @@ Interval max_i(Interval A, Interval B);
 
 Interval pow_i(Interval A, Interval B);
 
+Interval atan2_i(Interval A, Interval B);
+
 // Unary functions
 Interval abs_i(Interval A);
 Interval square_i(Interval A);

--- a/lib/fab/inc/fab/tree/math/math_r.h
+++ b/lib/fab/inc/fab/tree/math/math_r.h
@@ -24,6 +24,8 @@ float* max_r(const float* A, const float* B, float* R, int c);
 
 float* pow_r(const float* A, const float* B, float* R, int c);
 
+float* atan2_r(const float* A, const float* B, float* R, int c);
+
 // Unary functions
 float* abs_r(const float* A, float* R, int c);
 float* square_r(const float* A, float* R, int c);

--- a/lib/fab/inc/fab/tree/node/node.h
+++ b/lib/fab/inc/fab/tree/node/node.h
@@ -77,6 +77,8 @@ Node* min_n(Node* left, Node* right);
 Node* max_n(Node* left, Node* right);
 Node* pow_n(Node* left, Node* right);
 
+Node* atan2_n(Node* a, Node* b);
+
 // Unary arithmetic operators
 Node* abs_n(Node* n);
 Node* square_n(Node* n);

--- a/lib/fab/inc/fab/tree/node/opcodes.h
+++ b/lib/fab/inc/fab/tree/node/opcodes.h
@@ -26,6 +26,7 @@ typedef enum Opcode_ {
     OP_ASIN,
     OP_ACOS,
     OP_ATAN,
+    OP_ATAN2,
     OP_NEG,
     OP_EXP,
 

--- a/lib/fab/src/tree/eval.c
+++ b/lib/fab/src/tree/eval.c
@@ -30,6 +30,7 @@ float eval_f(MathTree* tree, const float x, const float y, const float z)
                 case OP_MIN:    node->results.f = min_f(A, B); break;
                 case OP_MAX:    node->results.f = max_f(A, B); break;
                 case OP_POW:    node->results.f = pow_f(A, B); break;
+                case OP_ATAN2:   node->results.f = atan2_f(A,B); break;
 
                 case OP_ABS:    node->results.f = abs_f(A); break;
                 case OP_SQUARE: node->results.f = square_f(A); break;
@@ -49,7 +50,7 @@ float eval_f(MathTree* tree, const float x, const float y, const float z)
 
                 case OP_CONST:  break;
                 default:
-                    printf("Unknown opcode!\n");
+                    printf("Unknown opcode! %i\n", node->opcode);
             }
         }
     }
@@ -82,6 +83,7 @@ Interval eval_i(MathTree* tree, const Interval X,
                 case OP_MIN:    node->results.i = min_i(A, B); break;
                 case OP_MAX:    node->results.i = max_i(A, B); break;
                 case OP_POW:    node->results.i = pow_i(A, B); break;
+                case OP_ATAN2:   node->results.i = atan2_i(A,B); break;
 
                 case OP_ABS:    node->results.i = abs_i(A); break;
                 case OP_SQUARE: node->results.i = square_i(A); break;
@@ -100,7 +102,7 @@ Interval eval_i(MathTree* tree, const Interval X,
                 case OP_Y:      node->results.i = Y_i(Y); break;
                 case OP_Z:      node->results.i = Z_i(Z); break;
                 default:
-                    printf("Unknown opcode!\n");
+                    printf("Unknown opcode! %i\n", node->opcode);
             }
         }
     }
@@ -132,6 +134,7 @@ float* eval_r(MathTree* tree, const Region r)
                 case OP_MIN:    min_r(A, B, R, c); break;
                 case OP_MAX:    max_r(A, B, R, c); break;
                 case OP_POW:    pow_r(A, B, R, c); break;
+                case OP_ATAN2:  atan2_r(A, B, R, c); break;
 
                 case OP_ABS:    abs_r(A, R, c); break;
                 case OP_SQUARE: square_r(A, R, c); break;
@@ -150,7 +153,7 @@ float* eval_r(MathTree* tree, const Region r)
                 case OP_Y:      Y_r(r.Y, R, c); break;
                 case OP_Z:      Z_r(r.Z, R, c); break;
                 default:
-                    printf("Unknown opcode!\n");
+                    printf("Unknown opcode! %i\n", node->opcode);
             }
         }
     }
@@ -184,6 +187,7 @@ derivative* eval_g(MathTree* tree, const Region r)
                 case OP_MIN:    min_g(A, B, R, c); break;
                 case OP_MAX:    max_g(A, B, R, c); break;
                 case OP_POW:    pow_g(A, B, R, c); break;
+                case OP_ATAN2:  atan2_g(A, B, R, c); break;
 
                 case OP_ABS:    abs_g(A, R, c); break;
                 case OP_SQUARE: square_g(A, R, c); break;
@@ -202,7 +206,7 @@ derivative* eval_g(MathTree* tree, const Region r)
                 case OP_Y:      Y_g(r.Y, R, c); break;
                 case OP_Z:      Z_g(r.Z, R, c); break;
                 default:
-                    printf("Unknown opcode!\n");
+                    printf("Unknown opcode! %i\n", node->opcode);
             }
         }
     }

--- a/lib/fab/src/tree/math/math_f.c
+++ b/lib/fab/src/tree/math/math_f.c
@@ -89,6 +89,11 @@ float atan_f(float A)
     return atan(A);
 }
 
+float atan2_f(float A, float B)
+{
+    return atan2(A, B);
+}
+
 float neg_f(float A)
 {
     return -A;

--- a/lib/fab/src/tree/math/math_g.c
+++ b/lib/fab/src/tree/math/math_g.c
@@ -120,7 +120,7 @@ derivative* atan2_g(const derivative* A, const derivative* B, derivative* R, int
         R[q].v = atan2(A[q].v, B[q].v);
         const float d = pow(A[q].v, 2) + pow(B[q].v, 2);
         for (int i=1; i<4; ++i)
-            INDEX(R) = -INDEX(A) / d + INDEX(B) / d;
+            INDEX(R) = (-INDEX(A)*B[q].v + INDEX(B)*A[q].v) / d;
     }
 }
 

--- a/lib/fab/src/tree/math/math_g.c
+++ b/lib/fab/src/tree/math/math_g.c
@@ -114,6 +114,16 @@ derivative* pow_g(const derivative* restrict A,
     return R;
 }
 
+derivative* atan2_g(const derivative* A, const derivative* B, derivative* R, int c) {
+    for (int q = 0; q < c; ++q)
+    {
+        R[q].v = atan2(A[q].v, B[q].v);
+        const float d = pow(A[q].v, 2) + pow(B[q].v, 2);
+        for (int i=1; i<4; ++i)
+            INDEX(R) = -INDEX(A) / d + INDEX(B) / d;
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 derivative* abs_g(const derivative* restrict A,

--- a/lib/fab/src/tree/math/math_g.c
+++ b/lib/fab/src/tree/math/math_g.c
@@ -122,6 +122,8 @@ derivative* atan2_g(const derivative* A, const derivative* B, derivative* R, int
         for (int i=1; i<4; ++i)
             INDEX(R) = (-INDEX(A)*B[q].v + INDEX(B)*A[q].v) / d;
     }
+
+    return R;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/lib/fab/src/tree/math/math_i.c
+++ b/lib/fab/src/tree/math/math_i.c
@@ -92,6 +92,14 @@ Interval pow_i(Interval A, Interval B)
     return i;
 }
 
+Interval atan2_i(Interval A, Interval B)
+{   //FIXME: CHECK FOR RIGHTER INTERVAL
+    Interval i;
+    i.lower = -M_PI;
+    i.upper = M_PI;
+    return i;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 Interval abs_i(Interval A)

--- a/lib/fab/src/tree/math/math_r.c
+++ b/lib/fab/src/tree/math/math_r.c
@@ -59,6 +59,13 @@ float* pow_r(const float* restrict A, const float* restrict B,
     return R;
 }
 
+float* atan2_r(const float* A, const float* B, float* R, int c)
+{
+    for (int q =0; q < c; ++q)
+        R[q] = atan2(A[q], B[q]);
+    return R;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 float* abs_r(const float* restrict A, float* R, int c)

--- a/lib/fab/src/tree/node/node_c.c
+++ b/lib/fab/src/tree/node/node_c.c
@@ -61,6 +61,7 @@ Node* min_n(Node* lhs, Node* rhs) { return binary_n(lhs, rhs, min_f, OP_MIN); }
 Node* max_n(Node* lhs, Node* rhs) { return binary_n(lhs, rhs, max_f, OP_MAX); }
 Node* pow_n(Node* lhs, Node* rhs) { return binary_n(lhs, rhs, pow_f, OP_POW); }
 
+Node* atan2_n(Node* a, Node* b) {return binary_n(a, b, atan2_f, OP_ATAN2); }
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/lib/fab/src/tree/node/opcodes.c
+++ b/lib/fab/src/tree/node/opcodes.c
@@ -18,6 +18,7 @@ const char* OPCODE_NAMES[] = {
     "OP_ASIN",
     "OP_ACOS",
     "OP_ATAN",
+    "OP_ATAN2",
     "OP_NEG",
     "OP_EXP",
 
@@ -47,6 +48,7 @@ const char* dot_symbol(Opcode op) {
         case OP_ASIN:   return "asin";
         case OP_ACOS:   return "acos";
         case OP_ATAN:   return "atan";
+        case OP_ATAN2:  return "atan2";
         case OP_NEG:    return "−";
         case OP_EXP:    return "exp";
         case OP_X:      return "X";
@@ -73,6 +75,7 @@ const char* dot_color(Opcode op) {
         case OP_ASIN:
         case OP_ACOS:
         case OP_ATAN:
+        case OP_ATAN2:
         case OP_EXP:
             return "goldenrod";
         case OP_MIN:
@@ -114,6 +117,7 @@ int dot_fontsize(Opcode op) {
         case OP_ASIN:
         case OP_ACOS:
         case OP_ATAN:
+        case OP_ATAN2:
         case OP_EXP:
             return 14;
         default:

--- a/lib/fab/src/tree/node/printers.c
+++ b/lib/fab/src/tree/node/printers.c
@@ -155,6 +155,15 @@ static void atan_p(Node* n, FILE* f)
     fprintf(f, ")");
 }
 
+static void atan2_p(Node* n, FILE* f)
+{
+    fprintf(f, "atan2");
+    base_p(n, f);
+    fprintf(f, "(");
+    fprint_node(n->lhs, f);
+    fprintf(f, ")");
+}
+
 static void neg_p(Node* n, FILE* f)
 {
     fprintf(f, "-");
@@ -226,6 +235,7 @@ void fprint_node(Node* n, FILE* f)
         case OP_ASIN:   asin_p(n, f); break;
         case OP_ACOS:   acos_p(n, f); break;
         case OP_ATAN:   atan_p(n, f); break;
+        case OP_ATAN2:  atan2_p(n, f); break;
         case OP_NEG:    neg_p(n, f); break;
         case OP_EXP:    exp_p(n, f); break;
 

--- a/lib/fab/src/tree/v2syntax.l
+++ b/lib/fab/src/tree/v2syntax.l
@@ -77,6 +77,7 @@ real				{integer}*("."{digit}+)?{exponent}?
 	"asin"			return TOKEN_ASIN;
 	"acos"			return TOKEN_ACOS;
 	"atan"			return TOKEN_ATAN;
+	"atan2"			return TOKEN_ATAN2;
 	"abs"			return TOKEN_ABS;
 	"sqrt"			return TOKEN_SQRT;
 	"exp"			return TOKEN_EXP;

--- a/lib/fab/src/tree/v2syntax.y
+++ b/lib/fab/src/tree/v2syntax.y
@@ -123,6 +123,7 @@ expr(E)		::= expr(L) DOUBLESTAR expr(R).			{	E = CACHED(pow_n(L, R)); 	}
 expr(E)		::= MIN LPAREN expr(L) COMMA expr(R) RPAREN.		{	E = CACHED(min_n(L, R)); 	}
 expr(E)		::= MAX LPAREN expr(L) COMMA expr(R) RPAREN.	{	E = CACHED(max_n(L, R)); 	}
 expr(E)		::= POW LPAREN expr(L) COMMA expr(R) RPAREN.	{	E = CACHED(pow_n(L, R)); 	}
+expr(E)		::= ATAN2 LPAREN expr(A) COMMA expr(B) RPAREN.	{	E = CACHED(atan2_n(A, B)); 	}
 
 expr(E)		::= SIN LPAREN expr(O) RPAREN.			{	E = CACHED(sin_n(O)); 	}
 expr(E)		::= COS LPAREN expr(O) RPAREN.			{	E = CACHED(cos_n(O)); 	}

--- a/py/fab/shapes.py
+++ b/py/fab/shapes.py
@@ -801,6 +801,29 @@ def repel(part, x, y, z, r):
 ################################################################################
 
 @preserve_color
+def cylinder_y_wrap(part, radius):
+    tx = "(X / %(radius)f)" % locals()
+    tz = "(Z / %(radius)f)" % locals()
+    dist = "(sqrt( (%(tx)s)**2 + (%(tz)s)**2 ))" % locals()
+    angle = "(atan2( %(tx)s, %(tz)s ))" % locals()
+
+    Xfn = "=%(angle)s * %(radius)f;" % locals()
+    Yfn = "_"
+    Zfn = "=(%(dist)s - 1) * %(radius)f;" % locals()
+
+    angle = "(X / %(radius)f)" % locals()
+    r = "(%(radius)f + Z)" % locals()
+    sina = "(sin(%(angle)s))" % locals()
+    cosa = "(cos(%(angle)s))" % locals()
+
+    Xfn_inv = "=%(r)s * %(sina)s;" % locals()
+    Yfn_inv = ""
+    Zfn_inv = "=%(r)s * %(cosa)s;" % locals()
+
+    return part.map(Transform(  Xfn, Yfn, Zfn,
+                                Xfn_inv, Yfn_inv, Zfn_inv))
+
+@preserve_color
 def twist_xy_z(part, x, y, z0, z1, t0, t1):
     # First, we'll move and scale so that the relevant part of the model
     # is at x=y=0 and scaled so that z is between 0 and 1.

--- a/py/nodes/Deform/cylinderwrap.node
+++ b/py/nodes/Deform/cylinderwrap.node
@@ -15,13 +15,13 @@ input('radius', float)
 tx = "(X / %(radius)f)" % locals()
 tz = "(Z / %(radius)f)" % locals()
 dist = "(sqrt( (%(tx)s)**2 + (%(tz)s)**2 ))" % locals()
-# angle = "atan2( %(tz)s, %(tx)s )" % locals()
+angle = "(atan2( %(tx)s, %(tz)s ))" % locals()
 # angle = "2 * atan( (sqrt( (%(tx)s) + (%(tz)s) ) - (%(tz)s)) / (%(tx)s) )" % locals()
-angle = "( 2 * atan(  %(tx)s / (  sqrt(%(tz)s + %(tx)s) + %(tz)s  )) )" % locals()
+# angle = "( 2 * atan(  %(tx)s / (  sqrt(%(tz)s + %(tx)s) + %(tz)s  )) )" % locals()
 
 Xfn = "=%(angle)s * %(radius)f;" % locals()
 Yfn = "_"
-Zfn = "=(%(dist)s-1) * %(radius)f;" % locals()
+Zfn = "=(%(dist)s - 1) * %(radius)f;" % locals()
 
 angle = "(X / %(radius)f)" % locals()
 r = "(%(radius)f + Z)" % locals()
@@ -33,4 +33,5 @@ Yfn_inv = ""
 Zfn_inv = "=%(r)s * %(cosa)s;" % locals()
 
 output("transformed", shape.map(
-    fab.types.Transform(Xfn, Yfn, Zfn, Xfn_inv, Yfn_inv, Zfn_inv)))
+    fab.types.Transform(Xfn, Yfn, Zfn,
+                        Xfn_inv, Yfn_inv, Zfn_inv)))

--- a/py/nodes/Deform/cylinderwrap.node
+++ b/py/nodes/Deform/cylinderwrap.node
@@ -1,0 +1,36 @@
+import fab
+
+title('Cylinder Wrap (Y-axis)')
+input('shape', fab.types.Shape)
+input('radius', float)
+
+#Xfn = "= %(radius)f * 2 * atan(X/%(radius)f / (sqrt((Z/%(radius)f)**2 + (X/%(radius)f)**2) + Z/%(radius)f));" % params
+#Xfn = "=%(radius)f * atan2( Z/%(radius)f, X/%(radius)f);" % params
+#Yfn = "_" % params
+#Zfn = "=%(radius)f * (sqrt( (X/%(radius)f)**2 + (Z/%(radius)f)**2) - 1);" % params
+#Xfn_inv = "=(%(radius)f+Z) * sin(X / %(radius)f);" % params
+#Yfn_inv = "" % params
+#Zfn_inv = "=(%(radius)f+Z) * cos(X / %(radius)f);" % params
+
+tx = "(X / %(radius)f)" % locals()
+tz = "(Z / %(radius)f)" % locals()
+dist = "(sqrt( (%(tx)s)**2 + (%(tz)s)**2 ))" % locals()
+# angle = "atan2( %(tz)s, %(tx)s )" % locals()
+# angle = "2 * atan( (sqrt( (%(tx)s) + (%(tz)s) ) - (%(tz)s)) / (%(tx)s) )" % locals()
+angle = "( 2 * atan(  %(tx)s / (  sqrt(%(tz)s + %(tx)s) + %(tz)s  )) )" % locals()
+
+Xfn = "=%(angle)s * %(radius)f;" % locals()
+Yfn = "_"
+Zfn = "=(%(dist)s-1) * %(radius)f;" % locals()
+
+angle = "(X / %(radius)f)" % locals()
+r = "(%(radius)f + Z)" % locals()
+sina = "(sin(%(angle)s))" % locals()
+cosa = "(cos(%(angle)s))" % locals()
+
+Xfn_inv = "=%(r)s * %(sina)s;" % locals()
+Yfn_inv = ""
+Zfn_inv = "=%(r)s * %(cosa)s;" % locals()
+
+output("transformed", shape.map(
+    fab.types.Transform(Xfn, Yfn, Zfn, Xfn_inv, Yfn_inv, Zfn_inv)))

--- a/py/nodes/Deform/cylinderwrap.node
+++ b/py/nodes/Deform/cylinderwrap.node
@@ -4,20 +4,10 @@ title('Cylinder Wrap (Y-axis)')
 input('shape', fab.types.Shape)
 input('radius', float)
 
-#Xfn = "= %(radius)f * 2 * atan(X/%(radius)f / (sqrt((Z/%(radius)f)**2 + (X/%(radius)f)**2) + Z/%(radius)f));" % params
-#Xfn = "=%(radius)f * atan2( Z/%(radius)f, X/%(radius)f);" % params
-#Yfn = "_" % params
-#Zfn = "=%(radius)f * (sqrt( (X/%(radius)f)**2 + (Z/%(radius)f)**2) - 1);" % params
-#Xfn_inv = "=(%(radius)f+Z) * sin(X / %(radius)f);" % params
-#Yfn_inv = "" % params
-#Zfn_inv = "=(%(radius)f+Z) * cos(X / %(radius)f);" % params
-
 tx = "(X / %(radius)f)" % locals()
 tz = "(Z / %(radius)f)" % locals()
 dist = "(sqrt( (%(tx)s)**2 + (%(tz)s)**2 ))" % locals()
 angle = "(atan2( %(tx)s, %(tz)s ))" % locals()
-# angle = "2 * atan( (sqrt( (%(tx)s) + (%(tz)s) ) - (%(tz)s)) / (%(tx)s) )" % locals()
-# angle = "( 2 * atan(  %(tx)s / (  sqrt(%(tz)s + %(tx)s) + %(tz)s  )) )" % locals()
 
 Xfn = "=%(angle)s * %(radius)f;" % locals()
 Yfn = "_"

--- a/py/nodes/Deform/cylinderwrap.node
+++ b/py/nodes/Deform/cylinderwrap.node
@@ -4,24 +4,4 @@ title('Cylinder Wrap (Y-axis)')
 input('shape', fab.types.Shape)
 input('radius', float, 1)
 
-tx = "(X / %(radius)f)" % locals()
-tz = "(Z / %(radius)f)" % locals()
-dist = "(sqrt( (%(tx)s)**2 + (%(tz)s)**2 ))" % locals()
-angle = "(atan2( %(tx)s, %(tz)s ))" % locals()
-
-Xfn = "=%(angle)s * %(radius)f;" % locals()
-Yfn = "_"
-Zfn = "=(%(dist)s - 1) * %(radius)f;" % locals()
-
-angle = "(X / %(radius)f)" % locals()
-r = "(%(radius)f + Z)" % locals()
-sina = "(sin(%(angle)s))" % locals()
-cosa = "(cos(%(angle)s))" % locals()
-
-Xfn_inv = "=%(r)s * %(sina)s;" % locals()
-Yfn_inv = ""
-Zfn_inv = "=%(r)s * %(cosa)s;" % locals()
-
-output("transformed", shape.map(
-    fab.types.Transform(Xfn, Yfn, Zfn,
-                        Xfn_inv, Yfn_inv, Zfn_inv)))
+output("wrapped", fab.shapes.cylinder_y_wrap(shape, radius))

--- a/py/nodes/Deform/cylinderwrap.node
+++ b/py/nodes/Deform/cylinderwrap.node
@@ -2,7 +2,7 @@ import fab
 
 title('Cylinder Wrap (Y-axis)')
 input('shape', fab.types.Shape)
-input('radius', float)
+input('radius', float, 1)
 
 tx = "(X / %(radius)f)" % locals()
 tz = "(Z / %(radius)f)" % locals()


### PR DESCRIPTION
Adds support for the atan2(y, x) function to the infix grammar.  

And, as a bonus, uses the atan2 function to provide a new distortion called "cylinderwrap.node" that maps an object onto the surface of a cylinder of an arbitrary radius.  Useful for taking a flat object and turning it into a ring, for example.

![screen shot 2015-06-19 at 6 13 38 pm](https://cloud.githubusercontent.com/assets/1689917/8264336/d661965e-16b2-11e5-8c7b-0542163a8bd0.png)
