### PR TITLE
Clean up fab math

### DIFF
--- a/lib/fab/inc/fab/tree/math/math_f.h
+++ b/lib/fab/inc/fab/tree/math/math_f.h
@@ -1,6 +1,8 @@
 #ifndef MATH_F_H
 #define MATH_F_H
 
+#include <math.h>
+
 #include "fab/tree/math/math_defines.h"
 
 #ifdef __cplusplus
@@ -14,34 +16,47 @@ extern "C" {
 */
 
 // Binary functions
-float add_f(float A, float B);
-float sub_f(float A, float B);
-float mul_f(float A, float B);
-float div_f(float A, float B);
+inline float add_f(float A, float B) { return A+B; }
+inline float sub_f(float A, float B) { return A-B; }
+inline float mul_f(float A, float B) { return A*B; }
+inline float div_f(float A, float B) { return A/B; }
+inline float min_f(float A, float B) { return fmin(A, B); }
+inline float max_f(float A, float B) { return fmax(A, B); }
+inline float pow_f(float A, float B) { return pow(A, B); }
 
-float min_f(float A, float B);
-float max_f(float A, float B);
+////////////////////////////////////////////////////////////////////////////////
 
-float pow_f(float A, float B);
+inline float abs_f(float A) { return fabs(A); }
+inline float square_f(float A) { return A*A; }
+inline float sqrt_f(float A) { return A < 0 ? 0 : sqrt(A); }
+inline float sin_f(float A) { return sin(A); }
+inline float cos_f(float A) { return cos(A); }
+inline float tan_f(float A) { return tan(A); }
 
-// Unary functions
-float abs_f(float A);
-float square_f(float A);
-float sqrt_f(float A);
-float sin_f(float A);
-float cos_f(float A);
-float tan_f(float A);
-float asin_f(float A);
-float acos_f(float A);
-float atan_f(float A);
-float atan2_f(float A, float B);
-float neg_f(float A);
-float exp_f(float A);
+inline float asin_f(float A)
+{
+    if (A < -1)     return -M_PI_2;
+    else if (A > 1) return M_PI_2;
+    else            return asin(A);
+}
 
-// Variables
-float X_f(float X);
-float Y_f(float Y);
-float Z_f(float Z);
+inline float acos_f(float A)
+{
+    if (A < -1)     return M_PI;
+    else if (A > 1) return 0;
+    else            return acos(A);
+}
+
+inline float atan_f(float A) { return atan(A); }
+inline float atan2_f(float A, float B) { return atan2(A, B); }
+inline float neg_f(float A) { return -A; }
+inline float exp_f(float A) { return exp(A); }
+
+////////////////////////////////////////////////////////////////////////////////
+
+inline float X_f(float X) { return X; }
+inline float Y_f(float Y) { return Y; }
+inline float Z_f(float Z) { return Z; }
 
 #ifdef __cplusplus
 }

--- a/lib/fab/src/tree/eval.c
+++ b/lib/fab/src/tree/eval.c
@@ -7,7 +7,6 @@
 
 #include "fab/tree/math/math_f.h"
 #include "fab/tree/math/math_i.h"
-#include "fab/tree/math/math_r.h"
 #include "fab/tree/math/math_g.h"
 
 float eval_f(MathTree* tree, const float x, const float y, const float z)

--- a/lib/fab/src/tree/math/math_f.c
+++ b/lib/fab/src/tree/math/math_f.c
@@ -1,116 +1,31 @@
-#include <math.h>
-
 #include "fab/tree/math/math_f.h"
 
-float add_f(float A, float B)
-{
-    return A+B;
-}
-
-float sub_f(float A, float B)
-{
-    return A-B;
-}
-
-float mul_f(float A, float B)
-{
-    return A*B;
-}
-
-float div_f(float A, float B)
-{
-    return A/B;
-}
-
-float min_f(float A, float B)
-{
-    return A < B ? A : B;
-}
-
-float max_f(float A, float B)
-{
-    return A > B ? A : B;
-}
-
-float pow_f(float A, float B)
-{
-    return pow(A, B);
-}
+extern inline float add_f(float A, float B);
+extern inline float sub_f(float A, float B);
+extern inline float mul_f(float A, float B);
+extern inline float div_f(float A, float B);
+extern inline float min_f(float A, float B);
+extern inline float max_f(float A, float B);
+extern inline float pow_f(float A, float B);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-float abs_f(float A)
-{
-    return fabs(A);
-}
+extern inline float abs_f(float A);
+extern inline float square_f(float A);
+extern inline float sqrt_f(float A);
+extern inline float sin_f(float A);
+extern inline float cos_f(float A);
+extern inline float tan_f(float A);
 
-float square_f(float A)
-{
-    return A*A;
-}
-
-float sqrt_f(float A)
-{
-    if (A < 0)  return 0;
-    else        return sqrt(A);
-}
-
-float sin_f(float A)
-{
-    return sin(A);
-}
-
-float cos_f(float A)
-{
-    return cos(A);
-}
-
-float tan_f(float A)
-{
-    return tan(A);
-}
-
-float asin_f(float A)
-{
-    if (A < -1)     return -M_PI_2;
-    else if (A > 1) return M_PI_2;
-    else            return asin(A);
-}
-
-float acos_f(float A)
-{
-    if (A < -1)     return M_PI;
-    else if (A > 1) return 0;
-    else            return acos(A);
-}
-
-float atan_f(float A)
-{
-    return atan(A);
-}
-
-float atan2_f(float A, float B)
-{
-    return atan2(A, B);
-}
-
-float neg_f(float A)
-{
-    return -A;
-}
-
-float exp_f(float A)
-{
-    return exp(A);
-}
+extern inline float asin_f(float A);
+extern inline float acos_f(float A);
+extern inline float atan_f(float A);
+extern inline float atan2_f(float A, float B);
+extern inline float neg_f(float A);
+extern inline float exp_f(float A);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-float X_f(float X)
-{ return X; }
-
-float Y_f(float Y)
-{ return Y; }
-
-float Z_f(float Z)
-{ return Z; }
+extern inline float X_f(float X);
+extern inline float Y_f(float Y);
+extern inline float Z_f(float Z);

--- a/lib/fab/src/tree/math/math_r.c
+++ b/lib/fab/src/tree/math/math_r.c
@@ -2,152 +2,47 @@
 #include <math.h>
 
 #include "fab/tree/math/math_r.h"
+#include "fab/tree/math/math_f.h"
 
-float* add_r(const float* restrict A, const float* restrict B,
-             float* restrict R, int c)
-{
-    for (int q = 0; q < c; ++q)
-        R[q] = A[q] + B[q];
-    return R;
+#define DUAL(name, fn) \
+float* name(const float* restrict A, const float* restrict B,   \
+         float* restrict R, int c)                              \
+{                                                               \
+    for (int q=0; q < c; ++c)                                   \
+        R[q] = fn(A[q], B[q]);                                  \
+    return R; \
 }
 
-float* sub_r(const float* restrict A, const float* restrict  B,
-             float* restrict R, int c)
-{
-    for (int q = 0; q < c; ++q)
-        R[q] = A[q] - B[q];
-    return R;
-}
-
-float* mul_r(const float* restrict A, const float* restrict B,
-             float* R, int c)
-{
-    for (int q = 0; q < c; ++q)
-        R[q] = A[q] * B[q];
-    return R;
-}
-
-float* div_r(const float* restrict A, const float* restrict B,
-             float* R, int c)
-{
-    for (int q = 0; q < c; ++q)
-        R[q] = A[q] / B[q];
-    return R;
-}
-
-float* min_r(const float* restrict A, const float* restrict B,
-             float* R, int c)
-{
-    for (int q = 0; q < c; ++q)
-        R[q] = fmin(A[q], B[q]);
-    return R;
-}
-
-float* max_r(const float* restrict A, const float* restrict B,
-             float* R, int c)
-{
-    for (int q = 0; q < c; ++q)
-        R[q] = fmax(A[q], B[q]);
-    return R;
-}
-
-float* pow_r(const float* restrict A, const float* restrict B,
-             float* R, int c)
-{
-    for (int q = 0; q < c; ++q)
-        R[q] = pow(A[q], B[q]);
-    return R;
-}
-
-float* atan2_r(const float* A, const float* B, float* R, int c)
-{
-    for (int q =0; q < c; ++q)
-        R[q] = atan2(A[q], B[q]);
-    return R;
-}
+DUAL(add_r, add_f);
+DUAL(sub_r, sub_f);
+DUAL(mul_r, mul_f);
+DUAL(div_r, div_f);
+DUAL(min_r, min_f);
+DUAL(max_r, max_f);
+DUAL(pow_r, pow_f);
+DUAL(atan2_r, atan2_f);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-float* abs_r(const float* restrict A, float* R, int c)
-{
-    for (int q=0; q < c; ++q)
-        R[q] = fabs(A[q]);
-    return R;
+#define SINGLE(name, fn) \
+float* name(const float* restrict A, float* restrict R, int c)  \
+{                                                               \
+    for (int q=0; q < c; ++c)                                   \
+        R[q] = fn(A[q]);                                        \
+    return R; \
 }
 
-float* square_r(const float* restrict A, float* R, int c)
-{
-    for (int q = 0; q < c; ++q)
-        R[q] = A[q]*A[q];
-    return R;
-}
-
-float* sqrt_r(const float* restrict A, float* R, int c)
-{
-    for (int q = 0; q < c; ++q)
-        if (A[q] < 0)   R[q] = 0;
-        else            R[q] = sqrt(A[q]);
-    return R;
-}
-
-float* sin_r(const float* restrict A, float* R, int c)
-{
-    for (int q = 0; q < c; ++q)
-        R[q] = sin(A[q]);
-    return R;
-}
-
-float* cos_r(const float* restrict A, float* R, int c)
-{
-    for (int q = 0; q < c; ++q)
-        R[q] = cos(A[q]);
-    return R;
-}
-
-float* tan_r(const float* restrict A, float* R, int c)
-{
-    for (int q = 0; q < c; ++q)
-        R[q] = tan(A[q]);
-    return R;
-}
-
-float* asin_r(const float* restrict A, float* R, int c)
-{
-    for (int q = 0; q < c; ++q)
-        R[q] = asin(A[q]);
-    return R;
-}
-
-float* acos_r(const float* restrict A, float* R, int c)
-{
-    for (int q = 0; q < c; ++q) {
-        if (A[q] < -1)      R[q] = M_PI;
-        else if (A[q] > 1)  R[q] = 0;
-        else                R[q] = acos(A[q]);
-    }
-    return R;
-}
-
-float* atan_r(const float* restrict A, float* R, int c)
-{
-    for (int q = 0; q < c; ++q)
-        R[q] = atan(A[q]);
-    return R;
-}
-
-float* neg_r(const float* restrict A, float* R, int c)
-{
-    for (int q = 0; q < c; ++q)
-        R[q] = -A[q];
-    return R;
-}
-
-float* exp_r(const float* restrict A, float* R, int c)
-{
-    for (int q = 0; q < c; ++q)
-        R[q] = exp(A[q]);
-    return R;
-}
+SINGLE(abs_r, abs_f);
+SINGLE(square_r, square_f);
+SINGLE(sqrt_r, sqrt_f);
+SINGLE(sin_r, sin_f);
+SINGLE(cos_r, cos_f);
+SINGLE(tan_r, tan_f);
+SINGLE(asin_r, asin_f);
+SINGLE(acos_r, acos_f);
+SINGLE(atan_r, atan_f);
+SINGLE(neg_r, neg_f);
+SINGLE(exp_r, exp_f);
 
 ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Removes duplicate code in `math_r` (by calling the base math functions in an array) and adds duplicate code in `math_g` (to eliminate weird struct casting tricks).