### PR TITLE
Use 'gtk' as default visual style on Linux

### DIFF
--- a/app/src/app/main.cpp
+++ b/app/src/app/main.cpp
@@ -5,6 +5,7 @@
 #include <QMessageBox>
 #include <QSurfaceFormat>
 #include <QTextCodec>
+#include <QStyleFactory>
 
 #include <iostream>
 
@@ -61,6 +62,11 @@ int main(int argc, char *argv[])
 #endif
     d += "/sb";
     fab::postInit(d.toStdString().c_str());
+
+    // Use 'gtk' as default visual style on Linux
+#if defined Q_OS_LINUX
+    a.setStyle(QStyleFactory::create("gtk"));
+#endif
 
     // Check to make sure that the fab module exists
     PyObject* fab = PyImport_ImportModule("fab");


### PR DESCRIPTION
On some Linux systems (explored this with elementary OS) qt/antimony uses fusion as the default style for menus, buttons and more. Let's set a default so it looks more unique and Linuxish!

*tested on Manjaro Linux 0.8.13 i686*