### PR TITLE
Support unioning an arbitrary number of objects

### DIFF
--- a/py/nodes/CSG/union.node
+++ b/py/nodes/CSG/union.node
@@ -1,7 +1,13 @@
 import fab.types
+import functools
+import operator
 
 title('Union')
-input('a', fab.types.Shape)
-input('b', fab.types.Shape)
+input('count', int, 2)
+for i in range(count):
+    input('in_%d' % i, fab.types.Shape)
 
-output('shape', a | b)
+vars = locals()
+output('shape', functools.reduce(
+    operator.or_,
+    [vars["in_%d" % i] for i in range(count)]))


### PR DESCRIPTION
This is a proof of concept PR for improving the CSG functions to support more than two objects in a single operation, which can cut down on duplicate nodes sufficiently.

If you like the approach, I'll happily expand the PR to support all of the CSG operations.