### PR TITLE
Make drag/drop area for connections to be much larger

### DIFF
--- a/app/src/ui/canvas/connection.cpp
+++ b/app/src/ui/canvas/connection.cpp
@@ -53,9 +53,9 @@ Connection::Connection(OutputPort* source, InputPort* target)
 
 void Connection::onPortsMoved()
 {
-    start_pos = source->mapToScene(source->boundingRect().center());
+    start_pos = source->mapToScene(source->dropRect().center());
     if (drag_state == CONNECTED)
-        end_pos = target->mapToScene(target->boundingRect().center());
+        end_pos = target->mapToScene(target->dropRect().center());
     prepareGeometryChange();
 }
 
@@ -245,7 +245,7 @@ void Connection::updateSnap()
     if (Port* p = gscene()->getInputPortNear(drag_pos, source->getDatum()))
     {
         has_snap_pos = true;
-        snap_pos = p->mapToScene(p->boundingRect().center());
+        snap_pos = p->mapToScene(p->dropRect().center());
     }
     else
     {

--- a/app/src/ui/canvas/inspector/inspector.cpp
+++ b/app/src/ui/canvas/inspector/inspector.cpp
@@ -31,6 +31,10 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 
+// 4 gets to edge of "buttons" in title-row, 4 more padding/margin
+// Probably there is a 4 lurking in canvas/inspector/inspector_buttons
+const int NodeInspector::TitleRightPadding = 8; 
+
 NodeInspector::NodeInspector(Node* node)
     : node(node), title_row(NULL),
       export_button(new InspectorExportButton(this)),
@@ -69,7 +73,7 @@ float NodeInspector::maxLabelWidth() const
 QRectF NodeInspector::boundingRect() const
 {
     float height = title_row->boundingRect().height() + 4;
-    float width =  title_row->boundingRect().width() + 8;
+    float width =  title_row->boundingRect().width() + TitleRightPadding;
 
     for (auto row=rows.begin(); row != rows.end(); ++row)
     {

--- a/app/src/ui/canvas/inspector/inspector.h
+++ b/app/src/ui/canvas/inspector/inspector.h
@@ -66,6 +66,8 @@ public:
     void setExportWorker(ExportWorker* worker);
     void clearExportWorker();
 
+    static const int TitleRightPadding;
+
 signals:
     void glowChanged(Node* node, bool g);
 

--- a/app/src/ui/canvas/inspector/inspector_row.cpp
+++ b/app/src/ui/canvas/inspector/inspector_row.cpp
@@ -9,6 +9,10 @@
 
 #include "graph/datum.h"
 
+const qreal InspectorRow::LeftPadding = 1;
+const qreal InspectorRow::LabelPadding = 10; // padding between label & datum-text
+const qreal InspectorRow::TextPadding = 5; // padding between datum-text & output-port
+         
 InspectorRow::InspectorRow(Datum* d, NodeInspector* parent)
     : QGraphicsObject(static_cast<QGraphicsItem*>(parent)),
       input(new InputPort(d, static_cast<QGraphicsItem*>(this))),
@@ -47,23 +51,27 @@ void InspectorRow::trigger(const DatumState& state)
 QRectF InspectorRow::boundingRect() const
 {
     const float height = editor->boundingRect().height();
-    const float width = 15      // Input port
+    const float width = 
+        LeftPadding
+        + Port::Width
         + labelWidth()    // Datum name
-        + 10        // Padding
+        + LabelPadding        // Padding
         + editor->boundingRect().width()    // Text field
-        + 5         // Padding
-        + 15;       // Output port
+        + TextPadding         // Padding
+        + Port::Width;       // Output port
     return QRectF(0, 0, width, height);
 }
 
 float InspectorRow::minWidth() const
 {
-    return 15       // Input port
+    return 
+           LeftPadding
+           + Port::Width
            + labelWidth() +  // Datum name
-           + 10     // Padding
+           + LabelPadding     // Padding
            + 150    // Text field
-           + 5      // Padding
-           + 15;    // Output port
+           + TextPadding      // Padding
+           + Port::Width;    // Output port
 }
 
 void InspectorRow::setWidth(float width)
@@ -85,7 +93,7 @@ bool InspectorRow::updateLayout()
 
     if (input)
     {
-        QPointF ipos(1, (bbox.height() - input->boundingRect().height()) / 2);
+        QPointF ipos(1 + LeftPadding, (bbox.height() - input->boundingRect().height()) / 2);
         if (input->pos() != ipos)
         {
             changed = true;
@@ -93,7 +101,7 @@ bool InspectorRow::updateLayout()
         }
     }
 
-    QPointF lpos(15 + label_width - label->boundingRect().width(),
+    QPointF lpos(LeftPadding + Port::Width + label_width - label->boundingRect().width(), // right justify
                  (bbox.height() - label->boundingRect().height())/2);
     if (label->pos() != lpos)
     {
@@ -101,7 +109,7 @@ bool InspectorRow::updateLayout()
         label->setPos(lpos);
     }
 
-    QPointF epos(15 + label_width + 10, 0);
+    QPointF epos(LeftPadding + Port::Width + label_width + LabelPadding, 0);
     if (editor->pos() != epos)
     {
         changed = true;
@@ -110,7 +118,7 @@ bool InspectorRow::updateLayout()
 
     if (output)
     {
-        QPointF opos(bbox.width() - output->boundingRect().width() - 1,
+        QPointF opos(bbox.width() - Port::Width,
                     (bbox.height() - output->boundingRect().height()) / 2);
         if (output->pos() != opos)
         {

--- a/app/src/ui/canvas/inspector/inspector_row.h
+++ b/app/src/ui/canvas/inspector/inspector_row.h
@@ -19,6 +19,10 @@ public:
 
     void trigger(const DatumState& state) override;
 
+    const static qreal LeftPadding; // padding between edge & input-port
+    const static qreal LabelPadding; // padding between label & datum-text
+    const static qreal TextPadding; // padding between datum-text & output-port
+
     InputPort* input;
     OutputPort* output;
     QGraphicsTextItem* label;
@@ -27,6 +31,7 @@ public:
 
     void setWidth(float width);
     float minWidth() const;
+    float labelWidth() const;
 
 public slots:
     /*
@@ -41,7 +46,6 @@ signals:
 protected:
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
                QWidget *widget) override;
-    float labelWidth() const;
 
     friend class NodeInspector;
 };

--- a/app/src/ui/canvas/port.h
+++ b/app/src/ui/canvas/port.h
@@ -16,13 +16,19 @@ class Port : public QGraphicsObject
 {
     Q_OBJECT
 public:
+    static const qreal Width; // The width of the actual "drag/drop" graphic-area
+    static const qreal PaintSize; // The x,y size of the painted spot
+
     explicit Port(Datum* d, QGraphicsItem* parent);
     virtual ~Port() {}
 
-    QRectF boundingRect() const override;
+    virtual QRectF boundingRect() const override =0;
     void paint(QPainter *painter,
                const QStyleOptionGraphicsItem *option,
                QWidget *widget) override;
+
+    QRectF dropRect() const {return paintRect(); }
+
     Datum* getDatum() const;
 
     QVariant itemChange(GraphicsItemChange change,
@@ -32,6 +38,9 @@ signals:
     void hiddenChanged();
 
 protected:
+    virtual qreal adjust_left_right() const;
+    QRectF paintRect() const;
+
     Datum* datum;
     bool hover;
     const QColor color;
@@ -44,6 +53,9 @@ public:
     virtual ~InputPort();
     void trigger(const DatumState& state) override;
     void install(Connection* c);
+    QRectF boundingRect() const;
+
+
 protected:
     QMap<const Datum*, Connection*> connections;
 };
@@ -52,10 +64,13 @@ class OutputPort : public Port
 {
 public:
     explicit OutputPort(Datum* d, QGraphicsItem* parent=NULL);
+    QRectF boundingRect() const;
+
 protected:
     void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
     void hoverEnterEvent(QGraphicsSceneHoverEvent* event) override;
     void hoverLeaveEvent(QGraphicsSceneHoverEvent* event) override;
+    qreal adjust_left_right() const;
 };
 
 #endif // PORT_H


### PR DESCRIPTION
Addresses #50.

Factored several constants to construct a larger drag/drop boundary for connections (easier to hit), and to locate the port's indicator.

The target-area is now: The height of the text box (i.e. the row height). For input-ports, the width is from the port's painted rect, to the right-edge of the text box. For output-ports, the width is from the edge of the text box (+1) to the edge of the node's (Inspector) box. See port.cpp, boundingRect().

This may be hackish: the port's boundingRect() is not it's actual boundary: because the connection drag/drop detection looks for the port's boundingRect(). And we want a larger drag/drop area. Will that break any Qt logic?

The actual connection point is the port's paintRect().

I adjusted the output-port position slightly, to make it symmetrical with the input-port (and nearer the edge). See OutputPort::adjust_left_right. Removing the TitlePadding-3 would put the paint-rect back where it has been.

