### PR TITLE
Change "isinf" to "std::isinf"

### DIFF
--- a/app/src/export/export_heightmap.cpp
+++ b/app/src/export/export_heightmap.cpp
@@ -103,7 +103,7 @@ void ExportHeightmapTask::render()
         .nk=1
     };
 
-    if (!isinf(bounds.zmin) && !isinf(bounds.zmax))
+    if (!std::isinf(bounds.zmin) && !std::isinf(bounds.zmax))
         r.nk = uint32_t((bounds.zmax - bounds.zmin) * resolution);
 
     build_arrays(

--- a/app/src/graph/hooks/export.cpp
+++ b/app/src/graph/hooks/export.cpp
@@ -92,9 +92,9 @@ object ScriptExportHooks::stl(tuple args, dict kwargs)
         bounds = get_bounds(kwargs);
 
     // Sanity-check bounds
-    if (isinf(bounds.xmin) || isinf(bounds.xmax) ||
-        isinf(bounds.ymin) || isinf(bounds.ymax) ||
-        isinf(bounds.zmin) || isinf(bounds.zmax))
+    if (std::isinf(bounds.xmin) || std::isinf(bounds.xmax) ||
+        std::isinf(bounds.ymin) || std::isinf(bounds.ymax) ||
+        std::isinf(bounds.zmin) || std::isinf(bounds.zmax))
     {
         throw AppHooks::Exception(
                 "Exporting mesh with invalid (infinite) bounds");
@@ -143,8 +143,8 @@ object ScriptExportHooks::heightmap(tuple args, dict kwargs)
         bounds = get_bounds(kwargs);
 
     // Sanity-check bounds
-    if (isinf(bounds.xmin) || isinf(bounds.xmax) ||
-        isinf(bounds.ymin) || isinf(bounds.ymax))
+    if (std::isinf(bounds.xmin) || std::isinf(bounds.xmax) ||
+        std::isinf(bounds.ymin) || std::isinf(bounds.ymax))
     {
         throw AppHooks::Exception(
                 "Exporting heightmap with invalid (infinite) bounds");

--- a/app/src/render/render_task.cpp
+++ b/app/src/render/render_task.cpp
@@ -64,10 +64,10 @@ void RenderTask::render()
     Q_ASSERT(get_shape.check());
     Shape s = get_shape();
 
-    if (!isinf(s.bounds.xmin) && !isinf(s.bounds.xmax) &&
-        !isinf(s.bounds.xmin) && !isinf(s.bounds.xmax))
+    if (!std::isinf(s.bounds.xmin) && !std::isinf(s.bounds.xmax) &&
+        !std::isinf(s.bounds.xmin) && !std::isinf(s.bounds.xmax))
     {
-        if (isinf(s.bounds.zmin) || isinf(s.bounds.zmax))
+        if (std::isinf(s.bounds.zmin) || std::isinf(s.bounds.zmax))
             render2d(s);
         else
             render3d(s);

--- a/app/src/ui/dialogs/resolution_dialog.cpp
+++ b/app/src/ui/dialogs/resolution_dialog.cpp
@@ -7,7 +7,7 @@
 ResolutionDialog::ResolutionDialog(Bounds bounds, bool dimensions, bool has_units,
                                    long max_voxels, QWidget* parent)
     : QDialog(parent), bounds(bounds), ui(new Ui::ResolutionDialog),
-      z_bounded(!isinf(bounds.zmax) && !isinf(bounds.zmin))
+      z_bounded(!std::isinf(bounds.zmax) && !std::isinf(bounds.zmin))
 {
     ui->setupUi(this);
 

--- a/lib/fab/src/types/bounds.cpp
+++ b/lib/fab/src/types/bounds.cpp
@@ -81,13 +81,13 @@ Bounds Bounds::map(Transform t) const
 
 bool Bounds::is_bounded_xy() const
 {
-    return !isinf(xmin) && !isinf(ymin) &&
-           !isinf(xmax) && !isinf(ymax);
+    return !std::isinf(xmin) && !std::isinf(ymin) &&
+           !std::isinf(xmax) && !std::isinf(ymax);
 
 }
 
 bool Bounds::is_bounded_xyz() const
 {
-    return !isinf(xmin) && !isinf(ymin) && !isinf(zmin) &&
-           !isinf(xmax) && !isinf(ymax) && !isinf(zmax);
+    return !std::isinf(xmin) && !std::isinf(ymin) && !std::isinf(zmin) &&
+           !std::isinf(xmax) && !std::isinf(ymax) && !std::isinf(zmax);
 }


### PR DESCRIPTION
Antimony was not able to build on my Arch Linux. I got messages like this:
`error: 'isinf' was not declared in this scope`
Now it compiles and work on my machines. Please try it on your machine before you pull this request.