### PR TITLE
Use new CMake Python discovery, with matching Boost::Python abi.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,29 +8,13 @@ set(CMAKE_CXX_FLAGS_DEBUG    "-O0")
 
 ################################################################################
 
-find_package(PythonLibs 3.3 REQUIRED)
+find_package(Python 3.3 REQUIRED COMPONENTS Interpreter Development)
 
 if (WIN32)
     add_definitions("-DBOOST_PYTHON_STATIC_LIB")
 endif()
 
-if (WIN32)
-    find_package(Boost REQUIRED COMPONENTS python3)
-elseif (APPLE)
-    foreach (PYTHON_NAME python3 python36 python37)
-        find_package(Boost QUIET COMPONENTS ${PYTHON_NAME})
-        if (${Boost_FOUND})
-            break()
-        endif()
-    endforeach()
-elseif (UNIX)
-    foreach (PYTHON_NAME python3 python-py36 python-py35 python-py34)
-        find_package(Boost QUIET COMPONENTS ${PYTHON_NAME})
-        if (${Boost_FOUND})
-            break()
-        endif()
-    endforeach()
-endif()
+find_package(Boost REQUIRED COMPONENTS python${Python_VERSION_MAJOR}${Python_VERSION_MINOR})
 
 if (NOT ${Boost_FOUND})
     message(FATAL_ERROR "Could not find boost::python3")

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -175,7 +175,7 @@ add_definitions(-D'GITREV="${GITREV}${GITDIFF}"'
 ################################################################################
 
 target_include_directories(${ANTIMONY_APP} SYSTEM PRIVATE
-    ${PYTHON_INCLUDE_DIRS}
+    ${Python_INCLUDE_DIR}
     ${Boost_INCLUDE_DIRS}
     ${AUTOGEN_TARGETS_FOLDER}
 )

--- a/lib/fab/CMakeLists.txt
+++ b/lib/fab/CMakeLists.txt
@@ -67,7 +67,7 @@ add_library(SbFab STATIC
 )
 
 target_include_directories(SbFab SYSTEM PRIVATE
-    ${PYTHON_INCLUDE_DIRS}
+    ${Python_INCLUDE_DIR}
     ${Boost_INCLUDE_DIRS}
     ${PNG_INCLUDE_DIR}
 )
@@ -79,7 +79,7 @@ target_include_directories(SbFab PRIVATE
 
 target_link_libraries(SbFab
     ${Boost_LIBRARIES}
-    ${PYTHON_LIBRARY}
+    ${Python_LIBRARY_RELEASE}
     ${PNG_LIBRARIES}
 )
 target_include_directories(SbFab PUBLIC inc)
@@ -98,7 +98,7 @@ target_link_libraries(SbFabTest SbFab)
 target_include_directories(SbFabTest SYSTEM PRIVATE
     ../../vendor
     ${Boost_INCLUDE_DIRS}
-    ${PYTHON_INCLUDE_DIRS}
+    ${Python_INCLUDE_DIR}
 )
 
 ################################################################################

--- a/lib/graph/CMakeLists.txt
+++ b/lib/graph/CMakeLists.txt
@@ -15,12 +15,12 @@ add_library(SbGraph STATIC
 )
 
 target_include_directories(SbGraph SYSTEM PRIVATE
-    ${PYTHON_INCLUDE_DIRS}
+    ${Python_INCLUDE_DIR}
     ${Boost_INCLUDE_DIRS}
 )
 target_link_libraries(SbGraph
     ${Boost_LIBRARIES}
-    ${PYTHON_LIBRARY}
+    ${Python_LIBRARY_RELEASE}
 )
 target_include_directories(SbGraph PUBLIC inc)
 
@@ -38,7 +38,7 @@ add_executable(SbGraphTest
 target_link_libraries(SbGraphTest SbGraph)
 
 target_include_directories(SbGraphTest SYSTEM PRIVATE
-    ${PYTHON_INCLUDE_DIRS}
+    ${Python_INCLUDE_DIR}
     ${Boost_INCLUDE_DIRS}
     ../../vendor
 )


### PR DESCRIPTION
CMake has a new Python discovery module, that can also export
major/minor version numbers. Switch to using it.

Boost, has also moved on to standard pythonXY abi component name
across all distributions/OS, thus use matching version ABI.

If one wants to compile against much older Boost, I guess we could add
fallback to search for Boost python3 component, but IMHO this should
not be necessory.