### PR TITLE
Fix call to yy_find_shift_action()

### DIFF
--- a/lib/fab/src/tree/v2syntax.y
+++ b/lib/fab/src/tree/v2syntax.y
@@ -40,7 +40,7 @@
 #ifndef NDEBUG
 	int n = sizeof(yyTokenName) / sizeof(yyTokenName[0]);
 	for (int i = 0; i < n; ++i) {
-		int a = yy_find_shift_action(yypParser, (YYCODETYPE)i);
+		int a = yy_find_shift_action(yymajor, (YYCODETYPE)i);
 		if (a < YYNSTATE + YYNRULE) {
 		printf("possible token: %s\n", yyTokenName[i]);
 		}


### PR DESCRIPTION
In %syntax_error, the call to yy_find_shift_action()
passes the parser as first argument, however, the
generated function prototype for this function in
v2syntax.lemon.cpp is:

```C
static YYACTIONTYPE yy_find_shift_action(
  YYCODETYPE iLookAhead,    /* The look-ahead token */
  YYACTIONTYPE stateno      /* Current state number */
);
```

... so the first parameter should actually be a YYCODETYPE.

Fixed by passing the correct variable (yymajor).

Not sure why this compiled before, did this function change
in lemon ?

Signed-off-by: Henner Zeller <h.zeller@acm.org>