### PR TITLE
Add autosave toggle to file menu

### DIFF
--- a/app/app/app.cpp
+++ b/app/app/app.cpp
@@ -25,6 +25,10 @@ App::App(int& argc, char** argv)
 {
     connect(undo_stack, &QUndoStack::cleanChanged,
             this, &App::cleanChanged);
+
+    autosave_timer = new QTimer(this);
+    connect(autosave_timer, &QTimer::timeout,
+        this, &App::onAutosave);
 }
 
 App::~App()
@@ -117,6 +121,22 @@ void App::onSave()
     }
 
     undo_stack->setClean();
+}
+
+void App::onAutosave()
+{
+    if (filename.isEmpty())
+        return;
+    return onSave();
+}
+
+void App::onToggleAutosave(bool enabled)
+{
+    if (enabled) {
+      autosave_timer->start(autosave_interval);
+    } else {
+      autosave_timer->stop();
+    }
 }
 
 void App::onSaveAs()

--- a/app/app/app.h
+++ b/app/app/app.h
@@ -4,6 +4,7 @@
 
 #include <QApplication>
 #include <QAction>
+#include <QTimer>
 
 class Graph;
 class GraphProxy;
@@ -87,6 +88,8 @@ public slots:
      */
     void onNew();
     void onSave();
+    void onAutosave();
+    void onToggleAutosave(bool);
     void onSaveAs();
     void onOpen();
     void onQuit();
@@ -126,4 +129,6 @@ protected:
     UndoStack* undo_stack;
 
     QString filename;
+    QTimer* autosave_timer;
+    int autosave_interval = 60000;
 };

--- a/app/window/base.cpp
+++ b/app/window/base.cpp
@@ -34,6 +34,8 @@ void BaseWindow::connectActions(App* app)
             app, &App::onSave);
     connect(ui->actionSaveAs, &QAction::triggered,
             app, &App::onSaveAs);
+    connect(ui->actionToggleAutosave, &QAction::triggered,
+            app, &App::onToggleAutosave);
     connect(ui->actionNew, &QAction::triggered,
             app, &App::onNew);
     connect(ui->actionOpen, &QAction::triggered,

--- a/app/window/base_window.ui
+++ b/app/window/base_window.ui
@@ -50,6 +50,7 @@
     <addaction name="separator"/>
     <addaction name="actionSave"/>
     <addaction name="actionSaveAs"/>
+    <addaction name="actionToggleAutosave"/>
     <addaction name="separator"/>
     <addaction name="actionCheckUpdate"/>
     <addaction name="separator"/>
@@ -126,6 +127,14 @@
   <action name="actionSaveAs">
    <property name="text">
     <string>Save As</string>
+   </property>
+  </action>
+  <action name="actionToggleAutosave">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Autosave</string>
    </property>
   </action>
   <action name="actionQuit">


### PR DESCRIPTION
I really love working with Antimony, but I've been losing work to random crashes somewhat frequently. It's a price I'm willing to pay, but I figured I should try to find a workaround. I added an autosave toggle to the File menu that triggers a save once every minute while enabled, which works for my use case but could definitely be improved. I wanted to get some input as to whether you'd be interested in including a feature like this, and if so, what sort of behavior or settings you think would be appropriate. I started working on an additional settings menu to adjust frequency, overwrite vs sequentially numbered saves, save directory, etc., but didn't want to overthink it without some input :grin: 

Let me know what you think, I use this software enough that I'm more than happy to put in some maintenance time on it.