### PR TITLE
Fix use of deprecated APIs in Qt 5.15

### DIFF
--- a/app/app/app.cpp
+++ b/app/app/app.cpp
@@ -88,7 +88,7 @@ QStringList App::nodePaths() const
         }
     }
 
-    return existing_paths.toList();
+    return existing_paths.values();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/app/canvas/canvas_view.cpp
+++ b/app/canvas/canvas_view.cpp
@@ -89,10 +89,10 @@ void CanvasView::mouseMoveEvent(QMouseEvent* event)
 
 void CanvasView::wheelEvent(QWheelEvent* event)
 {
-    QPointF a = mapToScene(event->pos());
-    auto s = pow(1.001, -event->delta());
+    QPointF a = mapToScene(event->position().toPoint());
+    auto s = pow(1.001, -event->angleDelta().y());
     scale(s, s);
-    auto d = a - mapToScene(event->pos());
+    auto d = a - mapToScene(event->position().toPoint());
     setSceneRect(sceneRect().translated(d.x(), d.y()));
 }
 

--- a/app/canvas/info.cpp
+++ b/app/canvas/info.cpp
@@ -2,6 +2,6 @@
 
 void CanvasInfo::unite(const CanvasInfo& other)
 {
-    inspector.unite(other.inspector);
-    subdatum.unite(other.subdatum);
+    inspector.insert(other.inspector);
+    subdatum.insert(other.subdatum);
 }

--- a/app/canvas/inspector/frame.cpp
+++ b/app/canvas/inspector/frame.cpp
@@ -59,7 +59,7 @@ QList<DatumRow*> InspectorFrame::visibleRows() const
         }
 
     // Sort datums by row order
-    qSort(rows.begin(), rows.end(),
+    std::sort(rows.begin(), rows.end(),
           [](const DatumRow* a, const DatumRow* b)
           { return a->getIndex() < b->getIndex(); });
 
@@ -159,7 +159,7 @@ void InspectorFrame::redoLayout()
     }
 
     // Sort datums by row order
-    qSort(rows.begin(), rows.end(),
+    std::sort(rows.begin(), rows.end(),
           [](const DatumRow* a, const DatumRow* b)
           { return a->getIndex() < b->getIndex(); });
 

--- a/app/script/editor.cpp
+++ b/app/script/editor.cpp
@@ -24,7 +24,7 @@ ScriptEditor::ScriptEditor(Script* script, QWidget* parent)
         QFont font;
         font.setFamily("Courier");
         QFontMetrics fm(font);
-        setTabStopWidth(fm.width("    "));
+        setTabStopDistance(fm.horizontalAdvance("    "));
         document()->setDefaultFont(font);
     }
 

--- a/app/viewport/render/task.cpp
+++ b/app/viewport/render/task.cpp
@@ -40,7 +40,7 @@ RenderTask* RenderTask::getNext(RenderInstance* parent) const
 
 void RenderTask::async()
 {
-    QTime timer;
+    QElapsedTimer timer;
     timer.start();
 
     boost::python::extract<const Shape&> get_shape(shape);

--- a/app/viewport/view.cpp
+++ b/app/viewport/view.cpp
@@ -319,9 +319,9 @@ void ViewportView::mouseReleaseEvent(QMouseEvent* event)
 
 void ViewportView::wheelEvent(QWheelEvent* event)
 {
-    QVector3D a = sceneToWorld(mapToScene(event->pos()));
-    scale *= pow(1.001, -event->delta());
-    QVector3D b = sceneToWorld(mapToScene(event->pos()));
+    QVector3D a = sceneToWorld(mapToScene(event->position().toPoint()));
+    scale *= pow(1.001, -event->angleDelta().y());
+    QVector3D b = sceneToWorld(mapToScene(event->position().toPoint()));
     center += a - b;
     update();
 }


### PR DESCRIPTION
This is necessary to build Antimony with Qt 5.15, older versions of Qt are being deprecated and removed by distributions.