### PR TITLE
v2parser: use delete to free new-allocated object

### DIFF
--- a/lib/fab/src/tree/v2parser.cpp
+++ b/lib/fab/src/tree/v2parser.cpp
@@ -81,7 +81,7 @@ bool v2parse(Node **result, const char* input, Node* X, Node* Y, Node *Z, NodeCa
     yy_delete_buffer(bufferState, scanner);
     yylex_destroy(scanner);
     v2ParseFree(parser, free);
-    free(locals->nodestack);
+    delete locals->nodestack;
     free(locals);
 
     return true;


### PR DESCRIPTION
As reported in Debian bug https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1080067 , it is required to use `delete` for memory allocated with `new`.