### PR TITLE
README.md: Update community package references

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,15 @@ To get started, there are two suggested options:
 - Download a [pre-built application](https://github.com/mkeeter/antimony/releases) (Mac only)
 - [Build from source](https://github.com/mkeeter/antimony/blob/develop/BUILDING.md) (Mac and Linux)
 
-There is also a community-supported package for [Fedora 22 or later](https://admin.fedoraproject.org/pkgdb/package/antimony/):
-```
-dnf install antimony
-```
-(or `dnf install antimony --enablerepo=updates-testing` to get testing builds)
+There are also community-supported packages for the following operating systems:
+* Debian 11 or later
+    * `apt install antimony`
+* Fedora 22 through 32 (no longer supported)
+    * `dnf install antimony`
+* FreeBSD 13 or later
+    * `pkg install antimony-cad`
+* Ubuntu 22.04 or later
+    *  `apt install antimony`
 
 ## Support
 


### PR DESCRIPTION
It would appear that Fedora no longer includes antimony, but several other OSes do.