### PR TITLE
Fix building with CMake 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 project(Antimony)
 set(CMAKE_BUILD_TYPE RELEASE)
 


### PR DESCRIPTION
This fixes https://bugs.debian.org/1112701
```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.
```